### PR TITLE
Keep track of whether desired number of keyboard events were inserted into the input stream

### DIFF
--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -3,7 +3,6 @@ import functools
 import inspect
 import time
 
-
 SendInput = ctypes.windll.user32.SendInput
 MapVirtualKey = ctypes.windll.user32.MapVirtualKeyW
 
@@ -92,17 +91,17 @@ KEYBOARD_MAPPING = {
     'subtract': 0x4A,
     'add': 0x4E,
     'decimal': 0x53,
-    #KEY_NUMPAD_ENTER: 0x9C + 1024,
-    #KEY_NUMPAD_1: 0x4F,
-    #KEY_NUMPAD_2: 0x50,
-    #KEY_NUMPAD_3: 0x51,
-    #KEY_NUMPAD_4: 0x4B,
-    #KEY_NUMPAD_5: 0x4C,
-    #KEY_NUMPAD_6: 0x4D,
-    #KEY_NUMPAD_7: 0x47,
-    #KEY_NUMPAD_8: 0x48,
-    #KEY_NUMPAD_9: 0x49,
-    #KEY_NUMPAD_0: 0x52,
+    # KEY_NUMPAD_ENTER: 0x9C + 1024,
+    # KEY_NUMPAD_1: 0x4F,
+    # KEY_NUMPAD_2: 0x50,
+    # KEY_NUMPAD_3: 0x51,
+    # KEY_NUMPAD_4: 0x4B,
+    # KEY_NUMPAD_5: 0x4C,
+    # KEY_NUMPAD_6: 0x4D,
+    # KEY_NUMPAD_7: 0x47,
+    # KEY_NUMPAD_8: 0x48,
+    # KEY_NUMPAD_9: 0x49,
+    # KEY_NUMPAD_0: 0x52,
     # end numpad
     'tab': 0x0F,
     'q': 0x10,
@@ -172,6 +171,8 @@ KEYBOARD_MAPPING = {
 # C struct redefinitions
 
 PUL = ctypes.POINTER(ctypes.c_ulong)
+
+
 class KeyBdInput(ctypes.Structure):
     _fields_ = [("wVk", ctypes.c_ushort),
                 ("wScan", ctypes.c_ushort),
@@ -179,27 +180,32 @@ class KeyBdInput(ctypes.Structure):
                 ("time", ctypes.c_ulong),
                 ("dwExtraInfo", PUL)]
 
+
 class HardwareInput(ctypes.Structure):
     _fields_ = [("uMsg", ctypes.c_ulong),
                 ("wParamL", ctypes.c_short),
                 ("wParamH", ctypes.c_ushort)]
+
 
 class MouseInput(ctypes.Structure):
     _fields_ = [("dx", ctypes.c_long),
                 ("dy", ctypes.c_long),
                 ("mouseData", ctypes.c_ulong),
                 ("dwFlags", ctypes.c_ulong),
-                ("time",ctypes.c_ulong),
+                ("time", ctypes.c_ulong),
                 ("dwExtraInfo", PUL)]
+
 
 class POINT(ctypes.Structure):
     _fields_ = [("x", ctypes.c_long),
                 ("y", ctypes.c_long)]
 
+
 class Input_I(ctypes.Union):
     _fields_ = [("ki", KeyBdInput),
-                 ("mi", MouseInput),
-                 ("hi", HardwareInput)]
+                ("mi", MouseInput),
+                ("hi", HardwareInput)]
+
 
 class Input(ctypes.Structure):
     _fields_ = [("type", ctypes.c_ulong),
@@ -216,7 +222,7 @@ def failSafeCheck():
     if FAILSAFE and tuple(position()) in FAILSAFE_POINTS:
         raise FailSafeException(
             "PyDirectInput fail-safe triggered from mouse moving to a corner of the screen. To disable this " \
-                "fail-safe, set pydirectinput.FAILSAFE to False. DISABLING FAIL-SAFE IS NOT RECOMMENDED."
+            "fail-safe, set pydirectinput.FAILSAFE to False. DISABLING FAIL-SAFE IS NOT RECOMMENDED."
         )
 
 
@@ -228,7 +234,6 @@ def _handlePause(_pause):
 
 # direct copy of _genericPyAutoGUIChecks()
 def _genericPyDirectInputChecks(wrappedFunction):
-
     @functools.wraps(wrappedFunction)
     def wrapper(*args, **kwargs):
         funcArgs = inspect.getcallargs(wrappedFunction, *args, **kwargs)
@@ -272,7 +277,6 @@ def size():
 # Ignored parameters: duration, tween, logScreenshot
 @_genericPyDirectInputChecks
 def mouseDown(x=None, y=None, button=PRIMARY, duration=None, tween=None, logScreenshot=None, _pause=True):
-
     if not x is None or not y is None:
         moveTo(x, y)
 
@@ -297,7 +301,6 @@ def mouseDown(x=None, y=None, button=PRIMARY, duration=None, tween=None, logScre
 # Ignored parameters: duration, tween, logScreenshot
 @_genericPyDirectInputChecks
 def mouseUp(x=None, y=None, button=PRIMARY, duration=None, tween=None, logScreenshot=None, _pause=True):
-    
     if not x is None or not y is None:
         moveTo(x, y)
 
@@ -321,8 +324,8 @@ def mouseUp(x=None, y=None, button=PRIMARY, duration=None, tween=None, logScreen
 
 # Ignored parameters: duration, tween, logScreenshot
 @_genericPyDirectInputChecks
-def click(x=None, y=None, clicks=1, interval=0.0, button=PRIMARY, duration=None, tween=None, logScreenshot=None, _pause=True):
-    
+def click(x=None, y=None, clicks=1, interval=0.0, button=PRIMARY, duration=None, tween=None, logScreenshot=None,
+          _pause=True):
     if not x is None or not y is None:
         moveTo(x, y)
 
@@ -339,7 +342,7 @@ def click(x=None, y=None, clicks=1, interval=0.0, button=PRIMARY, duration=None,
 
     for i in range(clicks):
         failSafeCheck()
-        
+
         extra = ctypes.c_ulong(0)
         ii_ = Input_I()
         ii_.mi = MouseInput(0, 0, 0, ev, 0, ctypes.pointer(extra))
@@ -417,6 +420,8 @@ def moveRel(xOffset=None, yOffset=None, duration=None, tween=None, logScreenshot
         ii_.mi = MouseInput(xOffset, yOffset, 0, MOUSEEVENTF_MOVE, 0, ctypes.pointer(extra))
         command = Input(ctypes.c_ulong(0), ii_)
         SendInput(1, ctypes.pointer(command), ctypes.sizeof(command))
+
+
 move = moveRel
 
 
@@ -431,7 +436,7 @@ move = moveRel
 @_genericPyDirectInputChecks
 def keyDown(key, logScreenshot=None, _pause=True):
     if not key in KEYBOARD_MAPPING or KEYBOARD_MAPPING[key] is None:
-        return 
+        return
 
     keybdFlags = KEYEVENTF_SCANCODE
 
@@ -446,14 +451,14 @@ def keyDown(key, logScreenshot=None, _pause=True):
             extra = ctypes.c_ulong(0)
             ii_ = Input_I()
             ii_.ki = KeyBdInput(0, hexKeyCode, KEYEVENTF_SCANCODE, 0, ctypes.pointer(extra))
-            x = Input( ctypes.c_ulong(1), ii_)
+            x = Input(ctypes.c_ulong(1), ii_)
             SendInput(1, ctypes.pointer(x), ctypes.sizeof(x))
 
     hexKeyCode = KEYBOARD_MAPPING[key]
     extra = ctypes.c_ulong(0)
     ii_ = Input_I()
     ii_.ki = KeyBdInput(0, hexKeyCode, keybdFlags, 0, ctypes.pointer(extra))
-    x = Input( ctypes.c_ulong(1), ii_)
+    x = Input(ctypes.c_ulong(1), ii_)
     SendInput(1, ctypes.pointer(x), ctypes.sizeof(x))
 
 
@@ -462,7 +467,7 @@ def keyDown(key, logScreenshot=None, _pause=True):
 @_genericPyDirectInputChecks
 def keyUp(key, logScreenshot=None, _pause=True):
     if not key in KEYBOARD_MAPPING or KEYBOARD_MAPPING[key] is None:
-        return 
+        return
 
     keybdFlags = KEYEVENTF_SCANCODE | KEYEVENTF_KEYUP
 
@@ -474,7 +479,7 @@ def keyUp(key, logScreenshot=None, _pause=True):
     extra = ctypes.c_ulong(0)
     ii_ = Input_I()
     ii_.ki = KeyBdInput(0, hexKeyCode, keybdFlags, 0, ctypes.pointer(extra))
-    x = Input( ctypes.c_ulong(1), ii_)
+    x = Input(ctypes.c_ulong(1), ii_)
     SendInput(1, ctypes.pointer(x), ctypes.sizeof(x))
 
     # if numlock is on and an arrow key is being pressed, we need to send an additional scancode
@@ -485,7 +490,7 @@ def keyUp(key, logScreenshot=None, _pause=True):
         extra = ctypes.c_ulong(0)
         ii_ = Input_I()
         ii_.ki = KeyBdInput(0, hexKeyCode, KEYEVENTF_SCANCODE | KEYEVENTF_KEYUP, 0, ctypes.pointer(extra))
-        x = Input( ctypes.c_ulong(1), ii_)
+        x = Input(ctypes.c_ulong(1), ii_)
         SendInput(1, ctypes.pointer(x), ctypes.sizeof(x))
 
 # Ignored parameters: logScreenshot
@@ -495,7 +500,7 @@ def press(keys, presses=1, interval=0.0, logScreenshot=None, _pause=True):
     if type(keys) == str:
         if len(keys) > 1:
             keys = keys.lower()
-        keys = [keys] # If keys is 'enter', convert it to ['enter'].
+        keys = [keys]  # If keys is 'enter', convert it to ['enter'].
     else:
         lowerKeys = []
         for s in keys:
@@ -524,7 +529,8 @@ def typewrite(message, interval=0.0, logScreenshot=None, _pause=True):
         press(c, _pause=False)
         time.sleep(interval)
         failSafeCheck()
-write = typewrite
 
+
+write = typewrite
 
 # Missing feature: hotkey functions


### PR DESCRIPTION
I had some issues recently where I suspected that input events were not actually inserted into the input stream.

The [SendInput documentation](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendinput#return-value)  state that SendInput returns a UINT of the number of events actually inserted into the input stream. The docs also mention that this method is not perfect, as input events could still have been blocked by UIPI.

This is, however, a method of tracking whether SendInput itself is aware of any errors. Simply keep track of how many events you wanted to insert and how many you did insert.

Existing users will not be impacted by this change as they most likely don't capture a return value of `keyUp`, `keyDown` or `press` (since there was `None`).