### PR TITLE
Complete overhaul (Add functionality, typing, etc.) for Python >=3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.vscode
 __pycache__
 /pydirectinput.egg-info
+/pydirectinput_rgx.egg-info
 /build
 /dist
 /publish_instructions.txt

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 /build
 /dist
 /publish_instructions.txt
+venv

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,14 @@
+[settings]
+multi_line_output=5
+line_length=80
+wrap_length=80
+use_parentheses=true
+indent="    "
+lines_after_imports=2
+include_trailing_comma=true
+balanced_wrapping=true
+import_heading_stdlib=native imports
+import_heading_thirdparty=pip imports
+import_heading_firstparty=local imports
+import_heading_firstparty=local imports
+import_heading_localfolder=internal imports

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2022 dev@reggx.eu
 Copyright (c) 2020 Ben Johnson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/OLD_README.md
+++ b/OLD_README.md
@@ -1,0 +1,67 @@
+# PyDirectInput
+
+This library aims to replicate the functionality of the PyAutoGUI mouse and keyboard inputs, but by utilizing DirectInput scan codes and the more modern SendInput() win32 function. PyAutoGUI uses Virtual Key Codes (VKs) and the deprecated mouse_event() and keybd_event() win32 functions. You may find that PyAutoGUI does not work in some applications, particularly in video games and other software that rely on DirectX. If you find yourself in that situation, give this library a try!
+
+`pip install pydirectinput`
+
+This package is intended to be used in conjunction with PyAutoGUI. You can continue to use PyAutoGUI for all of its cool features and simply substitute in PyDirectInput for the inputs that aren't working. The function interfaces are the same, but this package may not implement all optional parameters and features.
+
+Want to see a missing feature implemented? Why not give it a try yourself! I welcome all pull requests and will be happy to work with you to get a solution fleshed out. Get involved in open source! Learn more about programming! Pad your resume! Have fun!
+
+Source code available at https://github.com/learncodebygaming/pydirectinput
+
+Watch the tutorial here: https://www.youtube.com/watch?v=LFDGgFRqVIs
+
+## Example Usage
+
+```python
+    >>> import pyautogui
+    >>> import pydirectinput
+    >>> pydirectinput.moveTo(100, 150) # Move the mouse to the x, y coordinates 100, 150.
+    >>> pydirectinput.click() # Click the mouse at its current location.
+    >>> pydirectinput.click(200, 220) # Click the mouse at the x, y coordinates 200, 220.
+    >>> pydirectinput.move(None, 10)  # Move mouse 10 pixels down, that is, move the mouse relative to its current position.
+    >>> pydirectinput.doubleClick() # Double click the mouse at the
+    >>> pydirectinput.press('esc') # Simulate pressing the Escape key.
+    >>> pydirectinput.keyDown('shift')
+    >>> pydirectinput.keyUp('shift')
+```
+
+## Documentation
+
+The DirectInput key codes can be found by following the breadcrumbs in the documentation here: https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-input
+
+You might also be interested in the main SendInput documentation here: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendinput
+
+You can find a discussion of the problems with using vkCodes in video games here: https://stackoverflow.com/questions/14489013/simulate-python-keypresses-for-controlling-a-game
+
+## Testing
+
+To run the supplied tests: first setup a virtualenv. Then you can pip install this project in an editable state by doing `pip install -e .`. This allows any edits you make to these project files to be reflected when you run the tests. Run the test file with `python3 tests`.
+
+I have been testing with Half-Life 2 to confirm that these inputs work with DirectX games.
+
+## Features Implemented
+
+- Fail Safe Check
+- Pause
+- position()
+- size()
+- moveTo(x, y)
+- move(x, y) / moveRel(x, y)
+- mouseDown()
+- mouseUp()
+- click()
+- keyDown()
+- keyUp()
+- press()
+- write() / typewrite()
+
+## Features NOT Implemented
+
+- scroll functions
+- drag functions
+- hotkey functions
+- support for special characters requiring the shift key (ie. '!', '@', '#'...)
+- ignored parameters on mouse functions: duration, tween, logScreenshot
+- ignored parameters on keyboard functions: logScreenshot

--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ This library is a fork of https://github.com/learncodebygaming/pydirectinput
 Changes to the fork include:
 
 * Fixes for extended key codes
-* adding flake8 linting
-* adding mypy type hinting and adding annotations (**This makes this fork Python >=3.10 only!**)
+* Adding flake8 linting
+* Adding mypy type hinting and adding annotations (**This makes this fork Python >=3.10 only!**)
 * Adding a scroll function based on https://github.com/learncodebygaming/pydirectinput/pull/22
 * Adding a hotkey function based on https://github.com/learncodebygaming/pydirectinput/pull/30
+* Adding more available keyboard keys
+* Adding optional automatic shifting for certain keayboard keys in old down/up/press functions
+* Adding additional arguments for tighter timing control for press and typewrite functinos
+* Adding Unicode input functions that allow sending text that couldn't be sent by simple keyboard
 
 **This library uses in-line type annotations that require at least Python version 3.10 or higher and there are no plans to make the code backwards compatible to older Python versions!**
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Changes to the fork include:
 * Adding Scancode input functions that allow lower level access to SendInput's abstractions
 * Adding support for multi-monitor setups via virtual resolution
 * Adding support for swapped primary mouse buttons
+* Adding duration support for mouse functions
+* Adding sleep calibration for mouse duration
+* Adding automatic disabling of mouse acceleration for more accurate relative mouse movement
 * Increase documentation
 
 **This library uses in-line type annotations that require at least Python version 3.10 or higher and there are no plans to make the code backwards compatible to older Python versions!**
@@ -27,7 +30,7 @@ Changes to the fork include:
 - ~~drag functions~~
 - ~~hotkey functions~~
 - ~~support for special characters requiring the shift key (ie. '!', '@', '#'...)~~
-- ignored parameters on mouse functions: duration, tween, logScreenshot
+- ignored parameters on mouse functions: ~~duration~~, tween, logScreenshot
 - ignored parameters on keyboard functions: logScreenshot
 - automatic testing
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,79 @@
 # pydirectinput_rgx
 
-This library is a fork of https://github.com/learncodebygaming/pydirectinput
+This library is a fork of https://github.com/learncodebygaming/pydirectinput 1.0.4
 
-Changes to the fork include:
+This package extends PyDirectInput in multiple ways. It fixes some bugs, adds the remaining missing input functions that still required using PyAutoGUI and provides additional keyword-only arguments to give more precise control over function behavior.
+
+Contrary to the upstream PyDirectInput package, this package intends to replace PyAutoGUI almost completely for basic usage, skipping more advanced options like logging screenshots and custom tweening functions. This should reduce the need to install both PyDirectInput and PyAutoGUI side-by-side and thereby keep the number of dependencies to a minimum.
+
+This library is fully in-line type-annotated and passes `mypy --strict`. Unfortunately, that also means this package **only works on Python 3.10 or higher**. There are **no** plans to backport changes to older versions.
+
+This is why this package is available standalone and uses the same package name. There's no reason to use both side-by-side. Once Python's type annotations have reached wider adoption, this package may be merged back and integrated upstream. Until that moment, this package exists to fill that gap.
+
+## Okay, but what is PyDirectInput in the first place?
+
+PyDirectInput exists because PyAutoGUI uses older and less compatible API functions.
+
+In order to increase compatibility with DirectX software and games, the internals have been replaced with SendInput() and Scan Codes instead of Virtual Key Codes.
+
+For more information, see the original README at https://github.com/learncodebygaming/pydirectinput
+
+
+## Provided functions with same/similar signature to PyAutoGui:
+
+* Informational:
+  - `position()`
+  - `size()`
+  - `onScreen()`
+  - `isValidKey()`
+* Mouse input:
+  - `moveTo()`
+  - `move()` / `moveRel()`
+  - `mouseDown()`
+  - `mouseUp()`
+  - `click()` and derivatives:
+    - `leftClick()`
+    - `rightClick()`
+    - `middleClick()`
+    - `doubleClick()`
+    - `tripleClick()`
+  - `scroll()` / `vscroll()`
+  - `hscroll()`
+  - `dragTo()`
+  - `drag()` / `dragRel()`
+* Keyboard input:
+  - `keyDown()`
+  - `keyUp()`
+  - `press()`
+  - `hold()` (supports context manager)
+  - `write()` / `typewrite()`
+  - `hotkey()`
+
+
+### Additionally, keyboard input has been extended with :
+* low-level scancode_* functions that allow integer scancode as arguments:
+  - `scancode_keyDown()`
+  - `scancode_keyUp()`
+  - `scancode_press()`
+  - `scancode_hold()` (supports context manager)
+  - `scancode_hotkey()`
+* higher-level unicode_* functions that allow inserting Unicode characters into supported programs:
+  - `unicode_charDown()`
+  - `unicode_charUp()`
+  - `unicode_press()`
+  - `unicode_hold()` (supports context manager)
+  - `unicode_write()` / `unicode_typewrite()`
+  - `unicode_hotkey()`
+
+
+## Missing features compared to PyAutoGUI
+
+- `logScreenshot` arguments. No screenshots will be created.
+- `tween` arguments. The tweening function is hardcoded at the moment.
+
+___
+
+### Changelog compared to forked origin point PyDirectInput version 1.0.4:
 
 * Adding/fixing extended key codes
 * Adding flake8 linting
@@ -11,10 +82,10 @@ Changes to the fork include:
 * Adding hotkey functions based on https://github.com/learncodebygaming/pydirectinput/pull/30 and improve them
 * Adding more available keyboard keys
 * Adding optional automatic shifting for certain keayboard keys in old down/up/press functions
-* Adding additional arguments for tighter timing control for press and typewrite functinos
+* Adding additional arguments for tighter timing control for press and typewrite functions
 * Adding Unicode input functions that allow sending text that couldn't be sent by simple keyboard
 * Adding Scancode input functions that allow lower level access to SendInput's abstractions
-* Adding support for multi-monitor setups via virtual resolution
+* Adding support for multi-monitor setups via virtual resolution (most functions should work without just fine)
 * Adding support for swapped primary mouse buttons
 * Adding duration support for mouse functions
 * Adding sleep calibration for mouse duration
@@ -24,18 +95,6 @@ Changes to the fork include:
 **This library uses in-line type annotations that require at least Python version 3.10 or higher and there are no plans to make the code backwards compatible to older Python versions!**
 
 
-## Features NOT YET Implemented
-
-- ~~scroll functions~~
-- ~~drag functions~~
-- ~~hotkey functions~~
-- ~~support for special characters requiring the shift key (ie. '!', '@', '#'...)~~
-- ignored parameters on mouse functions: ~~duration~~, tween, logScreenshot
-- ignored parameters on keyboard functions: logScreenshot
-- automatic testing
-
 ___
-
-See the [old original README](OLD_README.md).
-
+See the [pydirectinput's original README](OLD_README.md).
 ___

--- a/README.md
+++ b/README.md
@@ -4,88 +4,35 @@ This library is a fork of https://github.com/learncodebygaming/pydirectinput
 
 Changes to the fork include:
 
-* Fixes for extended key codes
+* Adding/fixing extended key codes
 * Adding flake8 linting
 * Adding mypy type hinting and adding annotations (**This makes this fork Python >=3.10 only!**)
-* Adding a scroll function based on https://github.com/learncodebygaming/pydirectinput/pull/22
-* Adding a hotkey function based on https://github.com/learncodebygaming/pydirectinput/pull/30
+* Adding scroll functions based on https://github.com/learncodebygaming/pydirectinput/pull/22 and improve them
+* Adding hotkey functions based on https://github.com/learncodebygaming/pydirectinput/pull/30 and improve them
 * Adding more available keyboard keys
 * Adding optional automatic shifting for certain keayboard keys in old down/up/press functions
 * Adding additional arguments for tighter timing control for press and typewrite functinos
 * Adding Unicode input functions that allow sending text that couldn't be sent by simple keyboard
+* Adding Scancode input functions that allow lower level access to SendInput's abstractions
+* Adding support for multi-monitor setups via virtual resolution
+* Adding support for swapped primary mouse buttons
+* Increase documentation
 
 **This library uses in-line type annotations that require at least Python version 3.10 or higher and there are no plans to make the code backwards compatible to older Python versions!**
 
-See the old original README below.
 
-___
-___
-___
+## Features NOT YET Implemented
 
-# PyDirectInput
-
-This library aims to replicate the functionality of the PyAutoGUI mouse and keyboard inputs, but by utilizing DirectInput scan codes and the more modern SendInput() win32 function. PyAutoGUI uses Virtual Key Codes (VKs) and the deprecated mouse_event() and keybd_event() win32 functions. You may find that PyAutoGUI does not work in some applications, particularly in video games and other software that rely on DirectX. If you find yourself in that situation, give this library a try!
-
-`pip install pydirectinput`
-
-This package is intended to be used in conjunction with PyAutoGUI. You can continue to use PyAutoGUI for all of its cool features and simply substitute in PyDirectInput for the inputs that aren't working. The function interfaces are the same, but this package may not implement all optional parameters and features.
-
-Want to see a missing feature implemented? Why not give it a try yourself! I welcome all pull requests and will be happy to work with you to get a solution fleshed out. Get involved in open source! Learn more about programming! Pad your resume! Have fun!
-
-Source code available at https://github.com/learncodebygaming/pydirectinput
-
-Watch the tutorial here: https://www.youtube.com/watch?v=LFDGgFRqVIs
-
-## Example Usage
-
-```python
-    >>> import pyautogui
-    >>> import pydirectinput
-    >>> pydirectinput.moveTo(100, 150) # Move the mouse to the x, y coordinates 100, 150.
-    >>> pydirectinput.click() # Click the mouse at its current location.
-    >>> pydirectinput.click(200, 220) # Click the mouse at the x, y coordinates 200, 220.
-    >>> pydirectinput.move(None, 10)  # Move mouse 10 pixels down, that is, move the mouse relative to its current position.
-    >>> pydirectinput.doubleClick() # Double click the mouse at the
-    >>> pydirectinput.press('esc') # Simulate pressing the Escape key.
-    >>> pydirectinput.keyDown('shift')
-    >>> pydirectinput.keyUp('shift')
-```
-
-## Documentation
-
-The DirectInput key codes can be found by following the breadcrumbs in the documentation here: https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-input
-
-You might also be interested in the main SendInput documentation here: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendinput
-
-You can find a discussion of the problems with using vkCodes in video games here: https://stackoverflow.com/questions/14489013/simulate-python-keypresses-for-controlling-a-game
-
-## Testing
-
-To run the supplied tests: first setup a virtualenv. Then you can pip install this project in an editable state by doing `pip install -e .`. This allows any edits you make to these project files to be reflected when you run the tests. Run the test file with `python3 tests`.
-
-I have been testing with Half-Life 2 to confirm that these inputs work with DirectX games.
-
-## Features Implemented
-
-- Fail Safe Check
-- Pause
-- position()
-- size()
-- moveTo(x, y)
-- move(x, y) / moveRel(x, y)
-- mouseDown()
-- mouseUp()
-- click()
-- keyDown()
-- keyUp()
-- press()
-- write() / typewrite()
-
-## Features NOT Implemented
-
-- scroll functions
-- drag functions
-- hotkey functions
-- support for special characters requiring the shift key (ie. '!', '@', '#'...)
+- ~~scroll functions~~
+- ~~drag functions~~
+- ~~hotkey functions~~
+- ~~support for special characters requiring the shift key (ie. '!', '@', '#'...)~~
 - ignored parameters on mouse functions: duration, tween, logScreenshot
 - ignored parameters on keyboard functions: logScreenshot
+- automatic testing
+
+___
+
+See the [old original README](OLD_README.md).
+
+___

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ In order to increase compatibility with DirectX software and games, the internal
 For more information, see the original README at https://github.com/learncodebygaming/pydirectinput
 
 
+## Installation
+
+`pip install pydirectinput-rgx`
+
 ## Provided functions with same/similar signature to PyAutoGui:
 
 * Informational:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+# pydirectinput_rgx
+
+This library is a fork of https://github.com/learncodebygaming/pydirectinput
+
+Changes to the fork include:
+
+* Fixes for extended key codes
+* adding flake8 linting
+* adding mypy type hinting and adding annotations (**This makes this fork Python >=3.10 only!**)
+* Adding a scroll function based on https://github.com/learncodebygaming/pydirectinput/pull/22
+* Adding a hotkey function based on https://github.com/learncodebygaming/pydirectinput/pull/30
+
+**This library uses in-line type annotations that require at least Python version 3.10 or higher and there are no plans to make the code backwards compatible to older Python versions!**
+
+See the old original README below.
+
+___
+___
+___
+
 # PyDirectInput
 
 This library aims to replicate the functionality of the PyAutoGUI mouse and keyboard inputs, but by utilizing DirectInput scan codes and the more modern SendInput() win32 function. PyAutoGUI uses Virtual Key Codes (VKs) and the deprecated mouse_event() and keybd_event() win32 functions. You may find that PyAutoGUI does not work in some applications, particularly in video games and other software that rely on DirectX. If you find yourself in that situation, give this library a try!

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -1892,7 +1892,7 @@ def _add_one_step(
 
 
 # ------------------------------------------------------------------------------
-# ----- Enhanced Pointer Precision storage singleton ---------------------------
+# ----- Mouse acceleration and Ehanced Pointer Precision storage singleton -----
 class __MouseSpeedSettings:
     '''
     Allows controlled storage of Windows Enhanced Pointer Precision and mouse
@@ -3047,9 +3047,11 @@ def scancode_keyDown(
             )]
             expectedEvents += 1
 
+        scancode = scancode & 0xFFFF
+
         extendedFlag = _KEYEVENTF_EXTENDEDKEY if scancode >= 0xE000 else 0
         input_structs += [_create_keyboard_input(
-            wScan=scancode & 0xFFFF,
+            wScan=scancode,
             dwFlags=keybdFlags | extendedFlag
         )]
         expectedEvents += 1
@@ -3114,6 +3116,8 @@ def scancode_keyUp(
                 dwFlags=keybdFlags
             )]
             expectedEvents += 1
+
+        scancode = scancode & 0xFFFF
 
         extendedFlag = _KEYEVENTF_EXTENDEDKEY if scancode >= 0xE000 else 0
         input_structs += [_create_keyboard_input(

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -440,6 +440,9 @@ def keyDown(key, logScreenshot=None, _pause=True):
 
     keybdFlags = KEYEVENTF_SCANCODE
 
+    if KEYBOARD_MAPPING[key] >= 1024:
+        keybdFlags |= KEYEVENTF_EXTENDEDKEY
+
     # Init event tracking
     insertedEvents = 0
     expectedEvents = 1
@@ -481,6 +484,9 @@ def keyUp(key, logScreenshot=None, _pause=True):
         return
 
     keybdFlags = KEYEVENTF_SCANCODE | KEYEVENTF_KEYUP
+
+    if KEYBOARD_MAPPING[key] >= 1024:
+        keybdFlags |= KEYEVENTF_EXTENDEDKEY
 
     # Init event tracking
     insertedEvents = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,6 @@
 [mypy]
+strict = True
+show_error_codes = True
 ignore_missing_imports = True
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,14 @@
+[mypy]
+ignore_missing_imports = True
+
+[flake8]
+exclude = .git,.vscode,venv
+max-line-length = 100
+max-doc-length = 120
+indent-size = 4
+max-complexity = 15
+ignore =  # Errors
+          E121, # continuation line under-indented for hanging indent
+          E241, # multiple spaces after ':'
+          # Warnings
+          W503, # line break before binary operator (choose either 503 or 504)

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,12 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="PyDirectInput",
     version="1.0.4",
-    author="Ben Johnson",
-    author_email="ben@learncodebygaming.com",
+    # author="Ben Johnson",
+    # author_email="ben@learncodebygaming.com",
     description="Python mouse and keyboard input automation for Windows using Direct Input.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/learncodebygaming/pydirectinput",
+    # url="https://github.com/learncodebygaming/pydirectinput",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
@@ -19,5 +19,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: Microsoft :: Windows",
     ],
-    python_requires='>=3.4',
+    python_requires='>=3.10',
 )

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,18 @@ setuptools.setup(
     description="Python mouse and keyboard input automation for Windows using Direct Input.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/reggx/pydirectinput",
-    packages=setuptools.find_packages(),
+    url="https://github.com/reggx/pydirectinput_rgx",
+    packages=['pydirectinput'],
     classifiers=[
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: Microsoft :: Windows",
+        "Environment :: Win32 (MS Windows)",
+        "Topic :: Software Development :: Libraries",
+        "Typing :: Typed",
     ],
     python_requires='>=3.10',
+    license='MIT',
+    keywords='python directinput wrapper abstraction input gui automation'
 )

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="PyDirectInput",
-    version="1.0.4",
-    # author="Ben Johnson",
-    # author_email="ben@learncodebygaming.com",
+    name="pydirectinput_rgx",
+    version="2.0.0",
+    author="ReggX",
+    author_email="dev@reggx.eu",
     description="Python mouse and keyboard input automation for Windows using Direct Input.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    # url="https://github.com/learncodebygaming/pydirectinput",
+    url="https://github.com/reggx/pydirectinput",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -22,12 +22,12 @@ def mouse_return_accuracy():
     # when the mouse is moved relative, and then reversed relative again, confirm
     # that the cursor returns to the same position
     pydirectinput.moveTo(300, 300)
-    pos_start = pydirectinput._position()  # pyright: ignore[reportPrivateUsage]
+    pos_start = pydirectinput.position()  # pyright: ignore[reportPrivateUsage]
     time.sleep(1)
     pydirectinput.move(100, 0)
     time.sleep(1)
     pydirectinput.move(-100, 0)
-    pos_end = pydirectinput._position()  # pyright: ignore[reportPrivateUsage]
+    pos_end = pydirectinput.position()  # pyright: ignore[reportPrivateUsage]
     print(f"{pos_start} == {pos_end}? {pos_start == pos_end}")
 
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,5 +1,7 @@
+# native imports
 import time
 
+# local imports
 import pydirectinput
 
 
@@ -20,10 +22,13 @@ def mouse_return_accuracy():
     # when the mouse is moved relative, and then reversed relative again, confirm
     # that the cursor returns to the same position
     pydirectinput.moveTo(300, 300)
+    pos_start = pydirectinput.position()
     time.sleep(1)
     pydirectinput.move(100, 0)
     time.sleep(1)
     pydirectinput.move(-100, 0)
+    pos_end = pydirectinput.position()
+    print(f"{pos_start} == {pos_end}? {pos_start == pos_end}")
 
 
 def clicks_and_typing():
@@ -87,16 +92,24 @@ def relative_mouse():
 if __name__ == '__main__':
 
     time.sleep(4)
-    # trace_square()
-    # time.sleep(1)
-    # mouse_return_accuracy()
-    # time.sleep(1)
-    # clicks_and_typing()
-    # time.sleep(6)
-    # wasd_movement()
-    # time.sleep(1)
-    # basic_click()
-    # time.sleep(6)
-    # arrow_keys()
+    print("trace_square")
+    trace_square()
     time.sleep(1)
+    print("mouse_return_accuracy")
+    mouse_return_accuracy()
+    time.sleep(1)
+    print("clicks_and_typing")
+    clicks_and_typing()
+    time.sleep(1)
+    print("wasd_movement")
+    wasd_movement()
+    time.sleep(1)
+    print("basic_click")
+    basic_click()
+    time.sleep(1)
+    print("arrow_keys")
+    arrow_keys()
+    time.sleep(1)
+    print("relative_mouse")
     relative_mouse()
+    print("done")

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -17,7 +17,7 @@ def trace_square():
 
 
 def mouse_return_accuracy():
-    # when the mouse is moved relative, and then reversed relative again, confirm 
+    # when the mouse is moved relative, and then reversed relative again, confirm
     # that the cursor returns to the same position
     pydirectinput.moveTo(300, 300)
     time.sleep(1)
@@ -34,7 +34,7 @@ def clicks_and_typing():
     time.sleep(0.05)
     pydirectinput.keyUp('g')
     time.sleep(0.05)
-    pydirectinput.press(['c','v','t'])
+    pydirectinput.press(['c', 'v', 't'])
     time.sleep(0.05)
     pydirectinput.typewrite('myword')
 
@@ -85,22 +85,18 @@ def relative_mouse():
 
 
 if __name__ == '__main__':
-    
+
     time.sleep(4)
-    #trace_square()
-    #time.sleep(1)
-    #mouse_return_accuracy()
-    #time.sleep(1)
-    #clicks_and_typing()
-    #time.sleep(6)
-    #wasd_movement()
-    #time.sleep(1)
-    #basic_click()
-    #time.sleep(6)
-    #arrow_keys()
+    # trace_square()
+    # time.sleep(1)
+    # mouse_return_accuracy()
+    # time.sleep(1)
+    # clicks_and_typing()
+    # time.sleep(6)
+    # wasd_movement()
+    # time.sleep(1)
+    # basic_click()
+    # time.sleep(6)
+    # arrow_keys()
     time.sleep(1)
     relative_mouse()
-
-    
-    
-

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -22,12 +22,12 @@ def mouse_return_accuracy():
     # when the mouse is moved relative, and then reversed relative again, confirm
     # that the cursor returns to the same position
     pydirectinput.moveTo(300, 300)
-    pos_start = pydirectinput.position()
+    pos_start = pydirectinput._position()  # pyright: ignore[reportPrivateUsage]
     time.sleep(1)
     pydirectinput.move(100, 0)
     time.sleep(1)
     pydirectinput.move(-100, 0)
-    pos_end = pydirectinput.position()
+    pos_end = pydirectinput._position()  # pyright: ignore[reportPrivateUsage]
     print(f"{pos_start} == {pos_end}? {pos_start == pos_end}")
 
 

--- a/tests/coordinate_test.py
+++ b/tests/coordinate_test.py
@@ -1,0 +1,41 @@
+'''
+Test how well Windows normalized coordinates map to your real screen pixels.
+'''
+# pyright: reportPrivateUsage=false
+
+import pydirectinput
+
+
+# ------------------------------------------------------------------------------
+def coordinate_conversion_test(  # pyright: ignore[reportUnusedFunction]
+    virtual: bool = False,
+    dump: bool = False
+) -> None:
+    ''''''
+    def _raw_moveTo(x: int, y: int, virtual: bool = False) -> None:
+        dwFlags: int = (
+          pydirectinput._MOUSEEVENTF_MOVE | pydirectinput._MOUSEEVENTF_ABSOLUTE
+        )
+        if virtual:
+            dwFlags |= pydirectinput._MOUSEEVENTF_VIRTUALDESK
+        pydirectinput._send_input(pydirectinput._create_mouse_input(
+            dx=x, dy=y,
+            dwFlags=dwFlags
+        ))
+
+    results: list[tuple[int, int]] = []
+    _raw_moveTo(0, 32000, virtual=virtual)
+    pydirectinput._sleep(1)
+    for i in range(65536):
+        _raw_moveTo(i, 32000, virtual=virtual)
+        x, _ = pydirectinput._position()
+        results.append((i, x))
+    if dump:
+        import json
+        with open('coordinates.json', 'w')as fp:
+            json.dump(results, fp)
+# ------------------------------------------------------------------------------
+
+
+if __name__ == '__main__':
+    coordinate_conversion_test(virtual=True, dump=True)

--- a/tests/coordinate_test.py
+++ b/tests/coordinate_test.py
@@ -14,7 +14,8 @@ def coordinate_conversion_test(  # pyright: ignore[reportUnusedFunction]
     ''''''
     def _raw_moveTo(x: int, y: int, virtual: bool = False) -> None:
         dwFlags: int = (
-          pydirectinput._MOUSEEVENTF_MOVE | pydirectinput._MOUSEEVENTF_ABSOLUTE
+            pydirectinput._MOUSEEVENTF_MOVE
+            | pydirectinput._MOUSEEVENTF_ABSOLUTE
         )
         if virtual:
             dwFlags |= pydirectinput._MOUSEEVENTF_VIRTUALDESK
@@ -28,7 +29,7 @@ def coordinate_conversion_test(  # pyright: ignore[reportUnusedFunction]
     pydirectinput._sleep(1)
     for i in range(65536):
         _raw_moveTo(i, 32000, virtual=virtual)
-        x, _ = pydirectinput._position()
+        x, _ = pydirectinput.position()
         results.append((i, x))
     if dump:
         import json


### PR DESCRIPTION
Hey there,

I needed to make some changes for a private project of mine.

What began as a small set of changes to conform to `mypy --strict` ended up in a complete overhaul of the project, implementing more of PyAutoGUI's functions directly into pydirectinput and extending function signatures with optional keyword-only arguments. 

Your welcome to take the changes and integrate them upstream, there are some pitfalls though:

The whole package is in-line typed, which means it will need at least Python 3.10 to run.
It's also modifying the README to match my forked pypi package that I use for other stuff, so it can't be merged as is.

Please let me know if you're interested in merging this (maybe into another branch, because requring 3.10 is a pretty hefty compatibility hit).