### PR TITLE
Complete overhaul (Add functionality, typing, etc.) for Python >=3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.vscode
 __pycache__
 /pydirectinput.egg-info
+/pydirectinput_rgx.egg-info
 /build
 /dist
 /publish_instructions.txt

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ __pycache__
 /build
 /dist
 /publish_instructions.txt
-venv
+/venv*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 /build
 /dist
 /publish_instructions.txt
+venv

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,14 @@
+[settings]
+multi_line_output=5
+line_length=80
+wrap_length=80
+use_parentheses=true
+indent="    "
+lines_after_imports=2
+include_trailing_comma=true
+balanced_wrapping=true
+import_heading_stdlib=native imports
+import_heading_thirdparty=pip imports
+import_heading_firstparty=local imports
+import_heading_firstparty=local imports
+import_heading_localfolder=internal imports

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2022 dev@reggx.eu
 Copyright (c) 2020 Ben Johnson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/OLD_README.md
+++ b/OLD_README.md
@@ -1,0 +1,67 @@
+# PyDirectInput
+
+This library aims to replicate the functionality of the PyAutoGUI mouse and keyboard inputs, but by utilizing DirectInput scan codes and the more modern SendInput() win32 function. PyAutoGUI uses Virtual Key Codes (VKs) and the deprecated mouse_event() and keybd_event() win32 functions. You may find that PyAutoGUI does not work in some applications, particularly in video games and other software that rely on DirectX. If you find yourself in that situation, give this library a try!
+
+`pip install pydirectinput`
+
+This package is intended to be used in conjunction with PyAutoGUI. You can continue to use PyAutoGUI for all of its cool features and simply substitute in PyDirectInput for the inputs that aren't working. The function interfaces are the same, but this package may not implement all optional parameters and features.
+
+Want to see a missing feature implemented? Why not give it a try yourself! I welcome all pull requests and will be happy to work with you to get a solution fleshed out. Get involved in open source! Learn more about programming! Pad your resume! Have fun!
+
+Source code available at https://github.com/learncodebygaming/pydirectinput
+
+Watch the tutorial here: https://www.youtube.com/watch?v=LFDGgFRqVIs
+
+## Example Usage
+
+```python
+    >>> import pyautogui
+    >>> import pydirectinput
+    >>> pydirectinput.moveTo(100, 150) # Move the mouse to the x, y coordinates 100, 150.
+    >>> pydirectinput.click() # Click the mouse at its current location.
+    >>> pydirectinput.click(200, 220) # Click the mouse at the x, y coordinates 200, 220.
+    >>> pydirectinput.move(None, 10)  # Move mouse 10 pixels down, that is, move the mouse relative to its current position.
+    >>> pydirectinput.doubleClick() # Double click the mouse at the
+    >>> pydirectinput.press('esc') # Simulate pressing the Escape key.
+    >>> pydirectinput.keyDown('shift')
+    >>> pydirectinput.keyUp('shift')
+```
+
+## Documentation
+
+The DirectInput key codes can be found by following the breadcrumbs in the documentation here: https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-input
+
+You might also be interested in the main SendInput documentation here: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendinput
+
+You can find a discussion of the problems with using vkCodes in video games here: https://stackoverflow.com/questions/14489013/simulate-python-keypresses-for-controlling-a-game
+
+## Testing
+
+To run the supplied tests: first setup a virtualenv. Then you can pip install this project in an editable state by doing `pip install -e .`. This allows any edits you make to these project files to be reflected when you run the tests. Run the test file with `python3 tests`.
+
+I have been testing with Half-Life 2 to confirm that these inputs work with DirectX games.
+
+## Features Implemented
+
+- Fail Safe Check
+- Pause
+- position()
+- size()
+- moveTo(x, y)
+- move(x, y) / moveRel(x, y)
+- mouseDown()
+- mouseUp()
+- click()
+- keyDown()
+- keyUp()
+- press()
+- write() / typewrite()
+
+## Features NOT Implemented
+
+- scroll functions
+- drag functions
+- hotkey functions
+- support for special characters requiring the shift key (ie. '!', '@', '#'...)
+- ignored parameters on mouse functions: duration, tween, logScreenshot
+- ignored parameters on keyboard functions: logScreenshot

--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ This library is a fork of https://github.com/learncodebygaming/pydirectinput
 Changes to the fork include:
 
 * Fixes for extended key codes
-* adding flake8 linting
-* adding mypy type hinting and adding annotations (**This makes this fork Python >=3.10 only!**)
+* Adding flake8 linting
+* Adding mypy type hinting and adding annotations (**This makes this fork Python >=3.10 only!**)
 * Adding a scroll function based on https://github.com/learncodebygaming/pydirectinput/pull/22
 * Adding a hotkey function based on https://github.com/learncodebygaming/pydirectinput/pull/30
+* Adding more available keyboard keys
+* Adding optional automatic shifting for certain keayboard keys in old down/up/press functions
+* Adding additional arguments for tighter timing control for press and typewrite functinos
+* Adding Unicode input functions that allow sending text that couldn't be sent by simple keyboard
 
 **This library uses in-line type annotations that require at least Python version 3.10 or higher and there are no plans to make the code backwards compatible to older Python versions!**
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Changes to the fork include:
 * Adding Scancode input functions that allow lower level access to SendInput's abstractions
 * Adding support for multi-monitor setups via virtual resolution
 * Adding support for swapped primary mouse buttons
+* Adding duration support for mouse functions
+* Adding sleep calibration for mouse duration
+* Adding automatic disabling of mouse acceleration for more accurate relative mouse movement
 * Increase documentation
 
 **This library uses in-line type annotations that require at least Python version 3.10 or higher and there are no plans to make the code backwards compatible to older Python versions!**
@@ -27,7 +30,7 @@ Changes to the fork include:
 - ~~drag functions~~
 - ~~hotkey functions~~
 - ~~support for special characters requiring the shift key (ie. '!', '@', '#'...)~~
-- ignored parameters on mouse functions: duration, tween, logScreenshot
+- ignored parameters on mouse functions: ~~duration~~, tween, logScreenshot
 - ignored parameters on keyboard functions: logScreenshot
 - automatic testing
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,79 @@
 # pydirectinput_rgx
 
-This library is a fork of https://github.com/learncodebygaming/pydirectinput
+This library is a fork of https://github.com/learncodebygaming/pydirectinput 1.0.4
 
-Changes to the fork include:
+This package extends PyDirectInput in multiple ways. It fixes some bugs, adds the remaining missing input functions that still required using PyAutoGUI and provides additional keyword-only arguments to give more precise control over function behavior.
+
+Contrary to the upstream PyDirectInput package, this package intends to replace PyAutoGUI almost completely for basic usage, skipping more advanced options like logging screenshots and custom tweening functions. This should reduce the need to install both PyDirectInput and PyAutoGUI side-by-side and thereby keep the number of dependencies to a minimum.
+
+This library is fully in-line type-annotated and passes `mypy --strict`. Unfortunately, that also means this package **only works on Python 3.10 or higher**. There are **no** plans to backport changes to older versions.
+
+This is why this package is available standalone and uses the same package name. There's no reason to use both side-by-side. Once Python's type annotations have reached wider adoption, this package may be merged back and integrated upstream. Until that moment, this package exists to fill that gap.
+
+## Okay, but what is PyDirectInput in the first place?
+
+PyDirectInput exists because PyAutoGUI uses older and less compatible API functions.
+
+In order to increase compatibility with DirectX software and games, the internals have been replaced with SendInput() and Scan Codes instead of Virtual Key Codes.
+
+For more information, see the original README at https://github.com/learncodebygaming/pydirectinput
+
+
+## Provided functions with same/similar signature to PyAutoGui:
+
+* Informational:
+  - `position()`
+  - `size()`
+  - `onScreen()`
+  - `isValidKey()`
+* Mouse input:
+  - `moveTo()`
+  - `move()` / `moveRel()`
+  - `mouseDown()`
+  - `mouseUp()`
+  - `click()` and derivatives:
+    - `leftClick()`
+    - `rightClick()`
+    - `middleClick()`
+    - `doubleClick()`
+    - `tripleClick()`
+  - `scroll()` / `vscroll()`
+  - `hscroll()`
+  - `dragTo()`
+  - `drag()` / `dragRel()`
+* Keyboard input:
+  - `keyDown()`
+  - `keyUp()`
+  - `press()`
+  - `hold()` (supports context manager)
+  - `write()` / `typewrite()`
+  - `hotkey()`
+
+
+### Additionally, keyboard input has been extended with :
+* low-level scancode_* functions that allow integer scancode as arguments:
+  - `scancode_keyDown()`
+  - `scancode_keyUp()`
+  - `scancode_press()`
+  - `scancode_hold()` (supports context manager)
+  - `scancode_hotkey()`
+* higher-level unicode_* functions that allow inserting Unicode characters into supported programs:
+  - `unicode_charDown()`
+  - `unicode_charUp()`
+  - `unicode_press()`
+  - `unicode_hold()` (supports context manager)
+  - `unicode_write()` / `unicode_typewrite()`
+  - `unicode_hotkey()`
+
+
+## Missing features compared to PyAutoGUI
+
+- `logScreenshot` arguments. No screenshots will be created.
+- `tween` arguments. The tweening function is hardcoded at the moment.
+
+___
+
+### Changelog compared to forked origin point PyDirectInput version 1.0.4:
 
 * Adding/fixing extended key codes
 * Adding flake8 linting
@@ -11,10 +82,10 @@ Changes to the fork include:
 * Adding hotkey functions based on https://github.com/learncodebygaming/pydirectinput/pull/30 and improve them
 * Adding more available keyboard keys
 * Adding optional automatic shifting for certain keayboard keys in old down/up/press functions
-* Adding additional arguments for tighter timing control for press and typewrite functinos
+* Adding additional arguments for tighter timing control for press and typewrite functions
 * Adding Unicode input functions that allow sending text that couldn't be sent by simple keyboard
 * Adding Scancode input functions that allow lower level access to SendInput's abstractions
-* Adding support for multi-monitor setups via virtual resolution
+* Adding support for multi-monitor setups via virtual resolution (most functions should work without just fine)
 * Adding support for swapped primary mouse buttons
 * Adding duration support for mouse functions
 * Adding sleep calibration for mouse duration
@@ -24,18 +95,6 @@ Changes to the fork include:
 **This library uses in-line type annotations that require at least Python version 3.10 or higher and there are no plans to make the code backwards compatible to older Python versions!**
 
 
-## Features NOT YET Implemented
-
-- ~~scroll functions~~
-- ~~drag functions~~
-- ~~hotkey functions~~
-- ~~support for special characters requiring the shift key (ie. '!', '@', '#'...)~~
-- ignored parameters on mouse functions: ~~duration~~, tween, logScreenshot
-- ignored parameters on keyboard functions: logScreenshot
-- automatic testing
-
 ___
-
-See the [old original README](OLD_README.md).
-
+See the [pydirectinput's original README](OLD_README.md).
 ___

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ ___
 * Adding/fixing extended key codes
 * Adding flake8 linting
 * Adding mypy type hinting and adding annotations (**This makes this fork Python >=3.7 only!**)
-* Adding scroll functions based on https://github.com/learncodebygaming/pydirectinput/pull/22 and improve them
-* Adding hotkey functions based on https://github.com/learncodebygaming/pydirectinput/pull/30 and improve them
+* Adding scroll functions based on [learncodebygaming/PR #22](https://github.com/learncodebygaming/pydirectinput/pull/22) and improve them
+* Adding hotkey functions based on [learncodebygaming/PR #30](https://github.com/learncodebygaming/pydirectinput/pull/30) and improve them
 * Adding more available keyboard keys
 * Adding optional automatic shifting for certain keayboard keys in old down/up/press functions
 * Adding additional arguments for tighter timing control for press and typewrite functions
@@ -95,6 +95,7 @@ ___
 * Adding sleep calibration for mouse duration
 * Adding automatic disabling of mouse acceleration for more accurate relative mouse movement
 * Increase documentation
+* Improve performance of _genericPyDirectInputChecks decorator (Thanks Agade09 for [reggx/PR #1](https://github.com/ReggX/pydirectinput_rgx/pull/1))
 
 **This library uses in-line type annotations that require at least Python version 3.7 or higher and there are no plans to make the code backwards compatible to older Python versions!**
 

--- a/README.md
+++ b/README.md
@@ -4,88 +4,35 @@ This library is a fork of https://github.com/learncodebygaming/pydirectinput
 
 Changes to the fork include:
 
-* Fixes for extended key codes
+* Adding/fixing extended key codes
 * Adding flake8 linting
 * Adding mypy type hinting and adding annotations (**This makes this fork Python >=3.10 only!**)
-* Adding a scroll function based on https://github.com/learncodebygaming/pydirectinput/pull/22
-* Adding a hotkey function based on https://github.com/learncodebygaming/pydirectinput/pull/30
+* Adding scroll functions based on https://github.com/learncodebygaming/pydirectinput/pull/22 and improve them
+* Adding hotkey functions based on https://github.com/learncodebygaming/pydirectinput/pull/30 and improve them
 * Adding more available keyboard keys
 * Adding optional automatic shifting for certain keayboard keys in old down/up/press functions
 * Adding additional arguments for tighter timing control for press and typewrite functinos
 * Adding Unicode input functions that allow sending text that couldn't be sent by simple keyboard
+* Adding Scancode input functions that allow lower level access to SendInput's abstractions
+* Adding support for multi-monitor setups via virtual resolution
+* Adding support for swapped primary mouse buttons
+* Increase documentation
 
 **This library uses in-line type annotations that require at least Python version 3.10 or higher and there are no plans to make the code backwards compatible to older Python versions!**
 
-See the old original README below.
 
-___
-___
-___
+## Features NOT YET Implemented
 
-# PyDirectInput
-
-This library aims to replicate the functionality of the PyAutoGUI mouse and keyboard inputs, but by utilizing DirectInput scan codes and the more modern SendInput() win32 function. PyAutoGUI uses Virtual Key Codes (VKs) and the deprecated mouse_event() and keybd_event() win32 functions. You may find that PyAutoGUI does not work in some applications, particularly in video games and other software that rely on DirectX. If you find yourself in that situation, give this library a try!
-
-`pip install pydirectinput`
-
-This package is intended to be used in conjunction with PyAutoGUI. You can continue to use PyAutoGUI for all of its cool features and simply substitute in PyDirectInput for the inputs that aren't working. The function interfaces are the same, but this package may not implement all optional parameters and features.
-
-Want to see a missing feature implemented? Why not give it a try yourself! I welcome all pull requests and will be happy to work with you to get a solution fleshed out. Get involved in open source! Learn more about programming! Pad your resume! Have fun!
-
-Source code available at https://github.com/learncodebygaming/pydirectinput
-
-Watch the tutorial here: https://www.youtube.com/watch?v=LFDGgFRqVIs
-
-## Example Usage
-
-```python
-    >>> import pyautogui
-    >>> import pydirectinput
-    >>> pydirectinput.moveTo(100, 150) # Move the mouse to the x, y coordinates 100, 150.
-    >>> pydirectinput.click() # Click the mouse at its current location.
-    >>> pydirectinput.click(200, 220) # Click the mouse at the x, y coordinates 200, 220.
-    >>> pydirectinput.move(None, 10)  # Move mouse 10 pixels down, that is, move the mouse relative to its current position.
-    >>> pydirectinput.doubleClick() # Double click the mouse at the
-    >>> pydirectinput.press('esc') # Simulate pressing the Escape key.
-    >>> pydirectinput.keyDown('shift')
-    >>> pydirectinput.keyUp('shift')
-```
-
-## Documentation
-
-The DirectInput key codes can be found by following the breadcrumbs in the documentation here: https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-input
-
-You might also be interested in the main SendInput documentation here: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendinput
-
-You can find a discussion of the problems with using vkCodes in video games here: https://stackoverflow.com/questions/14489013/simulate-python-keypresses-for-controlling-a-game
-
-## Testing
-
-To run the supplied tests: first setup a virtualenv. Then you can pip install this project in an editable state by doing `pip install -e .`. This allows any edits you make to these project files to be reflected when you run the tests. Run the test file with `python3 tests`.
-
-I have been testing with Half-Life 2 to confirm that these inputs work with DirectX games.
-
-## Features Implemented
-
-- Fail Safe Check
-- Pause
-- position()
-- size()
-- moveTo(x, y)
-- move(x, y) / moveRel(x, y)
-- mouseDown()
-- mouseUp()
-- click()
-- keyDown()
-- keyUp()
-- press()
-- write() / typewrite()
-
-## Features NOT Implemented
-
-- scroll functions
-- drag functions
-- hotkey functions
-- support for special characters requiring the shift key (ie. '!', '@', '#'...)
+- ~~scroll functions~~
+- ~~drag functions~~
+- ~~hotkey functions~~
+- ~~support for special characters requiring the shift key (ie. '!', '@', '#'...)~~
 - ignored parameters on mouse functions: duration, tween, logScreenshot
 - ignored parameters on keyboard functions: logScreenshot
+- automatic testing
+
+___
+
+See the [old original README](OLD_README.md).
+
+___

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package extends PyDirectInput in multiple ways. It fixes some bugs, adds th
 
 Contrary to the upstream PyDirectInput package, this package intends to replace PyAutoGUI almost completely for basic usage, skipping more advanced options like logging screenshots and custom tweening functions. This should reduce the need to install both PyDirectInput and PyAutoGUI side-by-side and thereby keep the number of dependencies to a minimum.
 
-This library is fully in-line type-annotated and passes `mypy --strict`. Unfortunately, that also means this package **only works on Python 3.10 or higher**. There are **no** plans to backport changes to older versions.
+This library is fully in-line type-annotated and passes `mypy --strict`. Unfortunately, that also means this package **only works on Python 3.7 or higher**. There are **no** plans to backport changes to older versions.
 
 This is why this package is available standalone and uses the same package name. There's no reason to use both side-by-side. Once Python's type annotations have reached wider adoption, this package may be merged back and integrated upstream. Until that moment, this package exists to fill that gap.
 
@@ -81,7 +81,7 @@ ___
 
 * Adding/fixing extended key codes
 * Adding flake8 linting
-* Adding mypy type hinting and adding annotations (**This makes this fork Python >=3.10 only!**)
+* Adding mypy type hinting and adding annotations (**This makes this fork Python >=3.7 only!**)
 * Adding scroll functions based on https://github.com/learncodebygaming/pydirectinput/pull/22 and improve them
 * Adding hotkey functions based on https://github.com/learncodebygaming/pydirectinput/pull/30 and improve them
 * Adding more available keyboard keys
@@ -96,7 +96,7 @@ ___
 * Adding automatic disabling of mouse acceleration for more accurate relative mouse movement
 * Increase documentation
 
-**This library uses in-line type annotations that require at least Python version 3.10 or higher and there are no plans to make the code backwards compatible to older Python versions!**
+**This library uses in-line type annotations that require at least Python version 3.7 or higher and there are no plans to make the code backwards compatible to older Python versions!**
 
 
 ___

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ In order to increase compatibility with DirectX software and games, the internal
 For more information, see the original README at https://github.com/learncodebygaming/pydirectinput
 
 
+## Installation
+
+`pip install pydirectinput-rgx`
+
 ## Provided functions with same/similar signature to PyAutoGui:
 
 * Informational:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ ___
 * Adding sleep calibration for mouse duration
 * Adding automatic disabling of mouse acceleration for more accurate relative mouse movement
 * Increase documentation
-* Improve performance of _genericPyDirectInputChecks decorator (Thanks Agade09 for [reggx/PR #1](https://github.com/ReggX/pydirectinput_rgx/pull/1))
+* Improve performance of _genericPyDirectInputChecks decorator (Thanks Agade09 for [reggx/PR #1](https://github.com/ReggX/pydirectinput_rgx/pull/1) and [reggx/PR #2](https://github.com/ReggX/pydirectinput_rgx/pull/2))
 
 **This library uses in-line type annotations that require at least Python version 3.7 or higher and there are no plans to make the code backwards compatible to older Python versions!**
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+# pydirectinput_rgx
+
+This library is a fork of https://github.com/learncodebygaming/pydirectinput
+
+Changes to the fork include:
+
+* Fixes for extended key codes
+* adding flake8 linting
+* adding mypy type hinting and adding annotations (**This makes this fork Python >=3.10 only!**)
+* Adding a scroll function based on https://github.com/learncodebygaming/pydirectinput/pull/22
+* Adding a hotkey function based on https://github.com/learncodebygaming/pydirectinput/pull/30
+
+**This library uses in-line type annotations that require at least Python version 3.10 or higher and there are no plans to make the code backwards compatible to older Python versions!**
+
+See the old original README below.
+
+___
+___
+___
+
 # PyDirectInput
 
 This library aims to replicate the functionality of the PyAutoGUI mouse and keyboard inputs, but by utilizing DirectInput scan codes and the more modern SendInput() win32 function. PyAutoGUI uses Virtual Key Codes (VKs) and the deprecated mouse_event() and keybd_event() win32 functions. You may find that PyAutoGUI does not work in some applications, particularly in video games and other software that rely on DirectX. If you find yourself in that situation, give this library a try!

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -1892,7 +1892,7 @@ def _add_one_step(
 
 
 # ------------------------------------------------------------------------------
-# ----- Enhanced Pointer Precision storage singleton ---------------------------
+# ----- Mouse acceleration and Ehanced Pointer Precision storage singleton -----
 class __MouseSpeedSettings:
     '''
     Allows controlled storage of Windows Enhanced Pointer Precision and mouse
@@ -3047,9 +3047,11 @@ def scancode_keyDown(
             )]
             expectedEvents += 1
 
+        scancode = scancode & 0xFFFF
+
         extendedFlag = _KEYEVENTF_EXTENDEDKEY if scancode >= 0xE000 else 0
         input_structs += [_create_keyboard_input(
-            wScan=scancode & 0xFFFF,
+            wScan=scancode,
             dwFlags=keybdFlags | extendedFlag
         )]
         expectedEvents += 1
@@ -3114,6 +3116,8 @@ def scancode_keyUp(
                 dwFlags=keybdFlags
             )]
             expectedEvents += 1
+
+        scancode = scancode & 0xFFFF
 
         extendedFlag = _KEYEVENTF_EXTENDEDKEY if scancode >= 0xE000 else 0
         input_structs += [_create_keyboard_input(

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -3459,7 +3459,6 @@ def scancode_hotkey(
 
 # ----- keyDown ----------------------------------------------------------------
 # Ignored parameters: logScreenshot
-@_genericPyDirectInputChecks
 def keyDown(
     key: str,
     logScreenshot: None = None,
@@ -4056,11 +4055,11 @@ def unicode_hold(
 
     try:
         for c in chars:
-            downed += unicode_charDown(c)
+            downed += unicode_charDown(c, _pause=False)
         yield
     finally:
         for c in reversed(chars):
-            upped += unicode_charUp(c)
+            upped += unicode_charUp(c, _pause=False)
         if raise_on_failure and not (expectedPresses == downed == upped):
             raise PriorInputFailedException
 # ------------------------------------------------------------------------------

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -1839,6 +1839,7 @@ def onScreen(
     Returns whether the given xy coordinates are on the primary screen or not.
     '''
     if isinstance(x, Sequence):
+        assert not isinstance(x, int)  # remove int annotation, mypy needs this
         if y is not None:
             raise ValueError(
                 "onScreen() does not accept Sequence-types as first argument "

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -1770,7 +1770,7 @@ def _calc_normalized_screen_coord(
     # This alone is not enough, but we can do better by taking the average of
     # this pixel plus the next pixel.
     # In my testing this perfectly reflected the real pixel that SendInput moves
-    # to, down to the pixels that Windows themselves can't resolve.
+    # to, down to the pixels that Windows itself can't resolve.
     this_pixel: Final[int] = (
         (pixel_coord * 65536 + display_total - 1) // display_total
     )
@@ -2030,7 +2030,7 @@ class __MouseSpeedSettings:
 
 # ----- Temporarily disable Enhanced Pointer Precision -------------------------
 @contextmanager
-def _without_mouse_acceleration() -> Generator[None, None, None]:
+def _no_mouse_acceleration() -> Generator[None, None, None]:
     '''
     Context manager that allows temporarily disabling Windows Enhanced Pointer
     Precision on enter and restoring the previous setting on exit.
@@ -2048,6 +2048,8 @@ def _without_mouse_acceleration() -> Generator[None, None, None]:
         # modify mouse parameters
         if precision != 0:
             _set_mouse_parameters(th1, th2, 0)
+        if speed != 10:
+            _set_mouse_speed(10)
         yield
     finally:
         # restore mouse parameters
@@ -2916,7 +2918,7 @@ def moveRel(
             if disable_mouse_acceleration:
                 # Use a context manager to temporarily disable enhanced pointer
                 # precision
-                with _without_mouse_acceleration():
+                with _no_mouse_acceleration():
                     _send_input(input_struct)
             else:
                 _send_input(input_struct)
@@ -3940,7 +3942,7 @@ def unicode_press(
     Press the sequence of `chars` for `presses` amount of times.
 
     `chars` will be interpreted as a sequence of Unicode characters
-    (independet from keyboard layout). Supports complete Unicode character set
+    (independent from keyboard layout). Supports complete Unicode character set
     but may not be compatible with every application.
 
     Explanation of time parameters (seconds as floating point numbers):

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -1751,13 +1751,14 @@ def _genericPyDirectInputChecks(
     '''
     @functools.wraps(wrappedFunction)
     def wrapper(*args: _PS.args, **kwargs: _PS.kwargs) -> _RT:
+        _pause: Any
         if '_pause' in kwargs:
             _pause = kwargs['_pause']
         else:
             funcArgs: dict[str, Any] = (
                 inspect.getcallargs(wrappedFunction, *args, **kwargs)
             )
-           _pause = funcArgs.get("_pause")
+            _pause = funcArgs.get("_pause")
         _failSafeCheck()
         returnVal: _RT = wrappedFunction(*args, **kwargs)
         _handlePause(_pause)

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -3,10 +3,12 @@ Partial implementation of DirectInput function calls to simulate
 mouse and keyboard inputs.
 '''
 
+from __future__ import annotations
+
 # native imports
 import functools
 import inspect
-from threading import Lock
+import sys
 import time
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
@@ -16,11 +18,46 @@ from ctypes import (
 )
 from math import ceil, floor, log10
 from struct import unpack
-from typing import (
-    TYPE_CHECKING, Any, Callable, ClassVar, Final, Literal,
-    ParamSpec, Protocol, TypeAlias, TypeVar,
-)
-from typing import cast as hint_cast  # prevent confusion with ctypes.cast
+from threading import Lock
+
+# Windows-only
+if sys.platform != 'win32':
+    raise ImportError(
+        "This module makes Windows API calls and is thereby only available "
+        "on that plattform!"
+    )
+
+# Python 3.7 or higher
+if sys.version_info >= (3, 7):
+    from typing import Any, Callable, TypeVar, TYPE_CHECKING
+    from typing import cast as hint_cast  # prevent confusion with ctypes.cast
+else:
+    raise ImportError(
+        "This module is strictly typed and can't be used in Python <3.7!"
+    )
+
+# Python 3.8 or higher
+if sys.version_info >= (3, 8):
+    # native imports
+    from typing import ClassVar, Final, Literal, Protocol
+else:
+    # pip imports
+    from typing_extensions import ClassVar, Final, Literal, Protocol
+
+# Python 3.9 or higher
+if sys.version_info >= (3, 9):
+    _list = list
+else:
+    from typing import List
+    _list = List
+
+# Python 3.10 or higher
+if sys.version_info >= (3, 10):
+    # native imports
+    from typing import ParamSpec, TypeAlias
+else:
+    # pip imports
+    from typing_extensions import ParamSpec, TypeAlias
 
 
 # ------------------------------------------------------------------------------
@@ -522,7 +559,7 @@ update_MOUSEEVENT_mappings()  # call the function on import to set mappings.
 # ==============================================================================
 
 # ----- Pointer type to unsigned long ------------------------------------------
-_PUL_PyType: TypeAlias = type[_POINTER_TYPE[c_ulong]]
+_PUL_PyType: TypeAlias = "type[_POINTER_TYPE[c_ulong]]"
 _PUL: _PUL_PyType = POINTER(c_ulong)
 # ------------------------------------------------------------------------------
 
@@ -1338,7 +1375,7 @@ def _set_mouse_speed(mouse_speed: int) -> bool:
 # ==============================================================================
 
 # ----- Special class for key extended scancode sequences ----------------------
-class ScancodeSequence(list[int]):
+class ScancodeSequence(_list[int]):
     '''
     A special class with the sole purpose of representing extended scancode
     sequences that should be grouped together in a single INPUT array.
@@ -1352,7 +1389,7 @@ class ScancodeSequence(list[int]):
 
 
 # ----- TypeAlias for KEYBOARD_MAPPING values ----------------------------------
-ScancodeTypes: TypeAlias = int | ScancodeSequence
+ScancodeTypes: TypeAlias = "int | ScancodeSequence"
 '''
 Acceptable value types in KEYBOARD_MAPPING.
 

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -3493,7 +3493,7 @@ def keyDown(
     return scancode_keyDown(
         scancode,
         logScreenshot,
-        _pause,
+        _pause=_pause,
         auto_shift=auto_shift
     )
 # ------------------------------------------------------------------------------
@@ -3534,7 +3534,7 @@ def keyUp(
     return scancode_keyUp(
         scancode,
         logScreenshot,
-        _pause,
+        _pause=_pause,
         auto_shift=auto_shift
     )
 # ------------------------------------------------------------------------------

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -76,23 +76,23 @@ Actual time spent on sleeping with MINIMUM_SLEEP_IDEAL, rounded up for safety.
 
 
 # ----- Constants for the mouse button names -----------------------------------
-MOUSE_LEFT: Final[str] = "left"
+MOUSE_LEFT: str = "left"
 '''Name of left mouse button'''
-MOUSE_MIDDLE: Final[str] = "middle"
+MOUSE_MIDDLE: str = "middle"
 '''Name of middle mouse button'''
-MOUSE_RIGHT: Final[str] = "right"
+MOUSE_RIGHT: str = "right"
 '''Name of right mouse button'''
-MOUSE_PRIMARY: Final[str] = "primary"
+MOUSE_PRIMARY: str = "primary"
 '''Name of primary mouse button (left mouse button unless swapped)'''
-MOUSE_SECONDARY: Final[str] = "secondary"
+MOUSE_SECONDARY: str = "secondary"
 '''Name of secondary mouse button (right mouse button unless swapped)'''
-MOUSE_BUTTON4: Final[str] = "mouse4"
+MOUSE_BUTTON4: str = "mouse4"
 '''Name of first additional mouse button (usually a side button)'''
-MOUSE_X1: Final[str] = "x1"
+MOUSE_X1: str = "x1"
 '''Name of first additional mouse button (usually a side button)'''
-MOUSE_BUTTON5: Final[str] = "mouse5"
+MOUSE_BUTTON5: str = "mouse5"
 '''Name of second additional mouse button (usually a side button)'''
-MOUSE_X2: Final[str] = "x2"
+MOUSE_X2: str = "x2"
 '''Name of second additional mouse button (usually a side button)'''
 # ------------------------------------------------------------------------------
 
@@ -162,86 +162,86 @@ def calibrate_real_sleep_minimum(
 
 
 # ----- INPUT.type constants ---------------------------------------------------
-_INPUT_MOUSE: Literal[0x0000] = 0x0000  # c_ulong(0x0000)
+_INPUT_MOUSE: Final = 0x0000  # c_ulong(0x0000)
 '''The event is a mouse event. Use the mi structure of the union.'''
-_INPUT_KEYBOARD: Literal[0x0001] = 0x0001  # c_ulong(0x0001)
+_INPUT_KEYBOARD: Final = 0x0001  # c_ulong(0x0001)
 '''The event is a keyboard event. Use the ki structure of the union.'''
-_INPUT_HARDWARE: Literal[0x0002] = 0x0002  # c_ulong(0x0002)
+_INPUT_HARDWARE: Final = 0x0002  # c_ulong(0x0002)
 '''The event is a hardware event. Use the hi structure of the union.'''
 # ------------------------------------------------------------------------------
 
 
 # ----- MOUSEINPUT.mouseData constants -----------------------------------------
-_XBUTTON1: Literal[0x0001] = 0x0001  # c_ulong(0x0001)
+_XBUTTON1: Final = 0x0001  # c_ulong(0x0001)
 '''Set if the first X button is pressed or released.'''
-_XBUTTON2: Literal[0x0002] = 0x0002  # c_ulong(0x0002)
+_XBUTTON2: Final = 0x0002  # c_ulong(0x0002)
 '''Set if the second X button is pressed or released.'''
 # ------------------------------------------------------------------------------
 
 
 # ----- MOUSEINPUT.dwFlags constants -------------------------------------------
-_MOUSEEVENTF_MOVE: Literal[0x0001] = 0x0001  # c_ulong(0x0001)
+_MOUSEEVENTF_MOVE: Final = 0x0001  # c_ulong(0x0001)
 '''Movement occurred.'''
 
-_MOUSEEVENTF_LEFTDOWN: Literal[0x0002] = 0x0002  # c_ulong(0x0002)
+_MOUSEEVENTF_LEFTDOWN: Final = 0x0002  # c_ulong(0x0002)
 '''The left button was pressed.'''
-_MOUSEEVENTF_LEFTUP: Literal[0x0004] = 0x0004  # c_ulong(0x0004)
+_MOUSEEVENTF_LEFTUP: Final = 0x0004  # c_ulong(0x0004)
 '''The left button was released.'''
-_MOUSEEVENTF_LEFTCLICK: Final[int] = (
+_MOUSEEVENTF_LEFTCLICK: Final = (
     _MOUSEEVENTF_LEFTDOWN + _MOUSEEVENTF_LEFTUP  # c_ulong(0x0006)
 )
 '''Combined event: Left button was clicked.'''
 
-_MOUSEEVENTF_RIGHTDOWN: Literal[0x0008] = 0x0008  # c_ulong(0x0008)
+_MOUSEEVENTF_RIGHTDOWN: Final = 0x0008  # c_ulong(0x0008)
 '''The right button was pressed.'''
-_MOUSEEVENTF_RIGHTUP: Literal[0x0010] = 0x0010  # c_ulong(0x0010)
+_MOUSEEVENTF_RIGHTUP: Final = 0x0010  # c_ulong(0x0010)
 '''The right button was released.'''
-_MOUSEEVENTF_RIGHTCLICK: Final[int] = (
+_MOUSEEVENTF_RIGHTCLICK: Final = (
     _MOUSEEVENTF_RIGHTDOWN + _MOUSEEVENTF_RIGHTUP  # c_ulong(0x0018)
 )
 '''Combined event: Right button was clicked.'''
 
-_MOUSEEVENTF_MIDDLEDOWN: Literal[0x0020] = 0x0020  # c_ulong(0x0020)
+_MOUSEEVENTF_MIDDLEDOWN: Final = 0x0020  # c_ulong(0x0020)
 '''The middle button was pressed.'''
-_MOUSEEVENTF_MIDDLEUP: Literal[0x0040] = 0x0040  # c_ulong(0x0040)
+_MOUSEEVENTF_MIDDLEUP: Final = 0x0040  # c_ulong(0x0040)
 '''The middle button was released.'''
-_MOUSEEVENTF_MIDDLECLICK: Final[int] = (
+_MOUSEEVENTF_MIDDLECLICK: Final = (
     _MOUSEEVENTF_MIDDLEDOWN + _MOUSEEVENTF_MIDDLEUP  # c_ulong(0x0060)
 )
 '''Combined event: Middle button was clicked.'''
 
-_MOUSEEVENTF_XDOWN: Literal[0x0080] = 0x0080  # c_ulong(0x0080)
+_MOUSEEVENTF_XDOWN: Final = 0x0080  # c_ulong(0x0080)
 '''An X button was pressed.'''
-_MOUSEEVENTF_XUP: Literal[0x0100] = 0x0100  # c_ulong(0x0100)
+_MOUSEEVENTF_XUP: Final = 0x0100  # c_ulong(0x0100)
 '''An X button was released.'''
-_MOUSEEVENTF_XCLICK: Final[int] = (
+_MOUSEEVENTF_XCLICK: Final = (
     _MOUSEEVENTF_XDOWN + _MOUSEEVENTF_XUP  # c_ulong(0x0180)
 )
 '''Combined event: Side button was clicked.'''
 
-_MOUSEEVENTF_WHEEL: Literal[0x0800] = 0x0800  # c_ulong(0x0800)
+_MOUSEEVENTF_WHEEL: Final = 0x0800  # c_ulong(0x0800)
 '''
 The wheel was moved, if the mouse has a wheel.
 The amount of movement is specified in mouseData.
 '''
-_MOUSEEVENTF_HWHEEL: Literal[0x1000] = 0x1000  # c_ulong(0x1000)
+_MOUSEEVENTF_HWHEEL: Final = 0x1000  # c_ulong(0x1000)
 '''
 The wheel was moved horizontally, if the mouse has a wheel. The amount of
 movement is specified in mouseData.
 Windows XP/2000: This value is not supported.
 '''
 
-_MOUSEEVENTF_MOVE_NOCOALESCE: Literal[0x2000] = 0x2000  # c_ulong(0x2000)
+_MOUSEEVENTF_MOVE_NOCOALESCE: Final = 0x2000  # c_ulong(0x2000)
 '''
 The WM_MOUSEMOVE messages will not be coalesced. The default behavior is to
 coalesce WM_MOUSEMOVE messages.
 Windows XP/2000: This value is not supported.
 '''
-_MOUSEEVENTF_VIRTUALDESK: Literal[0x4000] = 0x4000  # c_ulong(0x4000)
+_MOUSEEVENTF_VIRTUALDESK: Final = 0x4000  # c_ulong(0x4000)
 '''
 Maps coordinates to the entire desktop. Must be used with MOUSEEVENTF_ABSOLUTE.
 '''
-_MOUSEEVENTF_ABSOLUTE: Literal[0x8000] = 0x8000  # c_ulong(0x8000)
+_MOUSEEVENTF_ABSOLUTE: Final = 0x8000  # c_ulong(0x8000)
 '''
 The dx and dy members contain normalized absolute coordinates. If the flag is
 not set, dxand dy contain relative data (the change in position since the last
@@ -253,7 +253,7 @@ information about relative mouse motion, see the following Remarks section.
 
 
 # ----- Scrolling distance -----------------------------------------------------
-_WHEEL_DELTA: Literal[120] = 120
+_WHEEL_DELTA: Final = 120
 '''
 The delta was set to 120 to allow Microsoft or other vendors to build
 finer-resolution wheels (a freely-rotating wheel with no notches) to send more
@@ -265,23 +265,23 @@ https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-mousewheel
 
 
 # ----- KEYBDINPUT.dwFlags Flags ------------------------------------------------
-_KEYEVENTF_EXTENDEDKEY: Literal[0x0001] = 0x0001  # c_ulong(0x0001)
+_KEYEVENTF_EXTENDEDKEY: Final = 0x0001  # c_ulong(0x0001)
 '''
 If specified, the scan code was preceded by a prefix byte that has the value
 0xE0 (224).
 '''
-_KEYEVENTF_KEYUP: Literal[0x0002] = 0x0002  # c_ulong(0x0002)
+_KEYEVENTF_KEYUP: Final = 0x0002  # c_ulong(0x0002)
 '''
 If specified, the key is being released. If not specified, the key is being
 pressed.
 '''
-_KEYEVENTF_UNICODE: Literal[0x0004] = 0x0004  # c_ulong(0x0004)
+_KEYEVENTF_UNICODE: Final = 0x0004  # c_ulong(0x0004)
 '''
 If specified, the system synthesizes a VK_PACKET keystroke. The wVk parameter
 must be zero. This flag can only be combined with the KEYEVENTF_KEYUP flag.
 For more information, see the Remarks section.
 '''
-_KEYEVENTF_SCANCODE: Literal[0x0008] = 0x0008  # c_ulong(0x0008)
+_KEYEVENTF_SCANCODE: Final = 0x0008  # c_ulong(0x0008)
 '''If specified, wScan identifies the key and wVk is ignored.'''
 # ------------------------------------------------------------------------------
 
@@ -331,33 +331,33 @@ movement along the x or y axis by up to four times.
 
 
 # ----- MapVirtualKey Map Types ------------------------------------------------
-_MAPVK_VK_TO_VSC: Literal[0] = 0  # c_unit(0)
+_MAPVK_VK_TO_VSC: Final = 0  # c_unit(0)
 '''
 The uCode parameter is a virtual-key code and is translated into a scan code.
 If it is a virtual-key code that does not distinguish between left- and
 right-hand keys, the left-hand scan code is returned.
 If there is no translation, the function returns 0.
 '''
-_MAPVK_VSC_TO_VK: Literal[1] = 1  # c_unit(1)
+_MAPVK_VSC_TO_VK: Final = 1  # c_unit(1)
 '''
 The uCode parameter is a scan code and is translated into a virtual-key code
 that does not distinguish between left- and right-hand keys.
 If there is no translation, the function returns 0.
 '''
-_MAPVK_VK_TO_CHAR: Literal[2] = 2  # c_unit(2)
+_MAPVK_VK_TO_CHAR: Final = 2  # c_unit(2)
 '''
 The uCode parameter is a virtual-key code and is translated into an unshifted
 character value in the low order word of the return value. Dead keys
 (diacritics) are indicated by setting the top bit of the return value.
 If there is no translation, the function returns 0.
 '''
-_MAPVK_VSC_TO_VK_EX: Literal[3] = 3  # c_unit(3)
+_MAPVK_VSC_TO_VK_EX: Final = 3  # c_unit(3)
 '''
 The uCode parameter is a scan code and is translated into a virtual-key code
 that distinguishes between left- and right-hand keys.
 If there is no translation, the function returns 0.
 '''
-_MAPVK_VK_TO_VSC_EX: Literal[4] = 4  # c_unit(4)
+_MAPVK_VK_TO_VSC_EX: Final = 4  # c_unit(4)
 '''
 Windows Vista and later: The uCode parameter is a virtual-key code and is
 translated into a scan code. If it is a virtual-key code that does not
@@ -370,7 +370,7 @@ If there is no translation, the function returns 0.
 
 
 # ----- GetSystemMetrics nIndex arguments --------------------------------------
-_SM_CXSCREEN: Literal[0] = 0
+_SM_CXSCREEN: Final = 0
 '''
 The width of the screen of the primary display monitor, in pixels. This is the
 same value obtained by calling GetDeviceCaps[1] as follows:
@@ -378,7 +378,7 @@ same value obtained by calling GetDeviceCaps[1] as follows:
 
 [1] https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-getdevicecaps
 '''
-_SM_CYSCREEN: Literal[1] = 1
+_SM_CYSCREEN: Final = 1
 '''
 The height of the screen of the primary display monitor, in pixels. This is the
 same value obtained by calling GetDeviceCaps[1] as follows:
@@ -386,30 +386,30 @@ same value obtained by calling GetDeviceCaps[1] as follows:
 
 [1] https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-getdevicecaps
 '''
-_SM_SWAPBUTTON: Literal[23] = 23
+_SM_SWAPBUTTON: Final = 23
 '''
 Nonzero if the meanings of the left and right mouse buttons are swapped;
 otherwise, 0.
 '''
-_SM_XVIRTUALSCREEN: Literal[76] = 76
+_SM_XVIRTUALSCREEN: Final = 76
 '''
 The coordinates for the left side of the virtual screen. The virtual screen is
 the bounding rectangle of all display monitors. The SM_CXVIRTUALSCREEN metric
 is the width of the virtual screen.
 '''
-_SM_YVIRTUALSCREEN: Literal[77] = 77
+_SM_YVIRTUALSCREEN: Final = 77
 '''
 The coordinates for the top of the virtual screen. The virtual screen is the
 bounding rectangle of all display monitors. The SM_CYVIRTUALSCREEN metric is
 the height of the virtual screen.
 '''
-_SM_CXVIRTUALSCREEN: Literal[78] = 78
+_SM_CXVIRTUALSCREEN: Final = 78
 '''
 The width of the virtual screen, in pixels. The virtual screen is the bounding
 rectangle of all display monitors. The SM_XVIRTUALSCREEN metric is the
 coordinates for the left side of the virtual screen.
 '''
-_SM_CYVIRTUALSCREEN: Literal[79] = 79
+_SM_CYVIRTUALSCREEN: Final = 79
 '''
 The height of the virtual screen, in pixels. The virtual screen is the bounding
 rectangle of all display monitors. The SM_YVIRTUALSCREEN metric is the
@@ -419,7 +419,7 @@ coordinates for the top of the virtual screen.
 
 
 # ----- SystemParametersInfoW uiAction arguments -------------------------------
-_SPI_GETMOUSE: Literal[0x0003] = 0x0003  # c_uint
+_SPI_GETMOUSE: Final = 0x0003  # c_uint
 '''
 Retrieves the two mouse threshold values and the mouse acceleration. The
 pvParam parameter must point to an array of three integers that receives these
@@ -427,7 +427,7 @@ values. See mouse_event[1] for further information.
 
 https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-mouse_event
 '''
-_SPI_SETMOUSE: Literal[0x0004] = 0x0004  # c_uint
+_SPI_SETMOUSE: Final = 0x0004  # c_uint
 '''
 Sets the two mouse threshold values and the mouse acceleration. The pvParam
 parameter must point to an array of three integers that specifies these values.
@@ -435,7 +435,7 @@ See mouse_event[1] for further information.
 
 https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-mouse_event
 '''
-_SPI_GETMOUSESPEED: Literal[0x0070] = 0x0070  # c_uint
+_SPI_GETMOUSESPEED: Final = 0x0070  # c_uint
 '''
 Retrieves the current mouse speed. The mouse speed determines how far the
 pointer will move based on the distance the mouse moves. The pvParam parameter
@@ -444,7 +444,7 @@ and 20 (fastest). A value of 10 is the default. The value can be set by an
 end-user using the mouse control panel application or by an application using
 SPI_SETMOUSESPEED.
 '''
-_SPI_SETMOUSESPEED: Literal[0x0071] = 0x0071  # c_uint
+_SPI_SETMOUSESPEED: Final = 0x0071  # c_uint
 '''
 Sets the current mouse speed. The pvParam parameter is an integer between
 1 (slowest) and 20 (fastest). A value of 10 is the default. This value is
@@ -454,9 +454,9 @@ typically set using the mouse control panel application.
 
 
 # ----- MOUSEEVENTF Index constants --------------------------------------------
-_MOUSE_PRESS: Literal[0] = 0
-_MOUSE_RELEASE: Literal[1] = 1
-_MOUSE_CLICK: Literal[2] = 2
+_MOUSE_PRESS: Final = 0
+_MOUSE_RELEASE: Final = 1
+_MOUSE_CLICK: Final = 2
 # ------------------------------------------------------------------------------
 
 
@@ -1363,13 +1363,13 @@ contained in a special class ScancodeSequence instance.
 
 
 # ----- Offsets for values in KEYBOARD_MAPPING ---------------------------------
-_OFFSET_EXTENDEDKEY: Literal[0xE000] = 0xE000
-_OFFSET_SHIFTKEY: Literal[0x10000] = 0x10000
+_OFFSET_EXTENDEDKEY: Final = 0xE000
+_OFFSET_SHIFTKEY: Final = 0x10000
 # ------------------------------------------------------------------------------
 
 
 # ----- KEYBOARD_MAPPING -------------------------------------------------------
-_SHIFT_SCANCODE: Literal[0x2A] = 0x2A  # Used in auto-shifting
+_SHIFT_SCANCODE: Final = 0x2A  # Used in auto-shifting
 # should be keyboard MAKE scancodes ( <0x80 )
 # some keys require the use of EXTENDEDKEY flags, they
 US_QWERTY_MAPPING: Final[dict[str, ScancodeTypes]] = {

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -59,14 +59,25 @@ else:
     # pip imports
     from typing_extensions import ParamSpec, TypeAlias
 
+# # Python 3.11 or higher
+# if sys.version_info >= (3, 11):
+#     pass
+# else:
+#     pass
 
 # ------------------------------------------------------------------------------
+# https://github.com/python/mypy/issues/7540#issuecomment-845741357
 if TYPE_CHECKING:
-    # https://github.com/python/mypy/issues/7540#issuecomment-845741357
-    _POINTER_TYPE = pointer
+    # We have to get the private Pointer type from typeshed to make
+    # the type checker shut up about the "incompatible types" error.
+    from ctypes import _Pointer  # pyright: ignore[reportPrivateUsage]
+    _POINTER_TYPE = _Pointer
 else:
     class __pointer:
-        '''Monkeypatch typed pointer from typeshed into ctypes'''
+        '''
+        Create pointer proxy class that translates square bracket notation
+        __pointer[type] into POINTER(type).
+        '''
         @classmethod
         def __class_getitem__(cls, item):
             return POINTER(item)

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -440,6 +440,9 @@ def keyDown(key, logScreenshot=None, _pause=True):
 
     keybdFlags = KEYEVENTF_SCANCODE
 
+    if KEYBOARD_MAPPING[key] >= 1024:
+        keybdFlags |= KEYEVENTF_EXTENDEDKEY
+
     # Init event tracking
     insertedEvents = 0
     expectedEvents = 1
@@ -481,6 +484,9 @@ def keyUp(key, logScreenshot=None, _pause=True):
         return
 
     keybdFlags = KEYEVENTF_SCANCODE | KEYEVENTF_KEYUP
+
+    if KEYBOARD_MAPPING[key] >= 1024:
+        keybdFlags |= KEYEVENTF_EXTENDEDKEY
 
     # Init event tracking
     insertedEvents = 0

--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -1751,12 +1751,16 @@ def _genericPyDirectInputChecks(
     '''
     @functools.wraps(wrappedFunction)
     def wrapper(*args: _PS.args, **kwargs: _PS.kwargs) -> _RT:
-        funcArgs: dict[str, Any] = (
-            inspect.getcallargs(wrappedFunction, *args, **kwargs)
-        )
+        if '_pause' in kwargs:
+            _pause = kwargs['_pause']
+        else:
+            funcArgs: dict[str, Any] = (
+                inspect.getcallargs(wrappedFunction, *args, **kwargs)
+            )
+           _pause = funcArgs.get("_pause")
         _failSafeCheck()
         returnVal: _RT = wrappedFunction(*args, **kwargs)
-        _handlePause(funcArgs.get("_pause"))
+        _handlePause(_pause)
         return returnVal
     return wrapper
 # ------------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+typing-extensions>=4.2.0, <5.0; python_version < '3.9'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,6 @@
 [mypy]
+strict = True
+show_error_codes = True
 ignore_missing_imports = True
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,14 @@
+[mypy]
+ignore_missing_imports = True
+
+[flake8]
+exclude = .git,.vscode,venv
+max-line-length = 100
+max-doc-length = 120
+indent-size = 4
+max-complexity = 15
+ignore =  # Errors
+          E121, # continuation line under-indented for hanging indent
+          E241, # multiple spaces after ':'
+          # Warnings
+          W503, # line break before binary operator (choose either 503 or 504)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pydirectinput_rgx",
-    version="2.0.5",
+    version="2.0.6",
     author="ReggX",
     author_email="dev@reggx.eu",
     description=(

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,13 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pydirectinput_rgx",
-    version="2.0.2",
+    version="2.0.3",
     author="ReggX",
     author_email="dev@reggx.eu",
-    description="Python mouse and keyboard input automation for Windows using Direct Input.",
+    description=(
+        "Python mouse and keyboard input automation for Windows using "
+        "Direct Input."
+    ),
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/reggx/pydirectinput_rgx",
@@ -17,6 +20,11 @@ setuptools.setup(
         'pydirectinput': ['py.typed']
     },
     classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
@@ -25,7 +33,10 @@ setuptools.setup(
         "Topic :: Software Development :: Libraries",
         "Typing :: Typed",
     ],
-    python_requires='>=3.10',
+    install_requires=[
+        "typing-extensions>=4.2.0, <5.0; python_version < '3.9'"
+    ],
+    python_requires='>=3.7',
     license='MIT',
     keywords='python directinput wrapper abstraction input gui automation'
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pydirectinput_rgx",
-    version="2.0.1",
+    version="2.0.2",
     author="ReggX",
     author_email="dev@reggx.eu",
     description="Python mouse and keyboard input automation for Windows using Direct Input.",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pydirectinput_rgx",
-    version="2.0.3",
+    version="2.0.4",
     author="ReggX",
     author_email="dev@reggx.eu",
     description=(
@@ -20,16 +20,18 @@ setuptools.setup(
         'pydirectinput': ['py.typed']
     },
     classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Win32 (MS Windows)",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: Microsoft :: Windows",
-        "Environment :: Win32 (MS Windows)",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries",
         "Typing :: Typed",
     ],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pydirectinput_rgx",
-    version="2.0.4",
+    version="2.0.5",
     author="ReggX",
     author_email="dev@reggx.eu",
     description=(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pydirectinput_rgx",
-    version="2.0.0",
+    version="2.0.1",
     author="ReggX",
     author_email="dev@reggx.eu",
     description="Python mouse and keyboard input automation for Windows using Direct Input.",
@@ -13,6 +13,9 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/reggx/pydirectinput_rgx",
     packages=['pydirectinput'],
+    package_data={
+        'pydirectinput': ['py.typed']
+    },
     classifiers=[
         "Programming Language :: Python :: 3.10",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,12 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="PyDirectInput",
     version="1.0.4",
-    author="Ben Johnson",
-    author_email="ben@learncodebygaming.com",
+    # author="Ben Johnson",
+    # author_email="ben@learncodebygaming.com",
     description="Python mouse and keyboard input automation for Windows using Direct Input.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/learncodebygaming/pydirectinput",
+    # url="https://github.com/learncodebygaming/pydirectinput",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
@@ -19,5 +19,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: Microsoft :: Windows",
     ],
-    python_requires='>=3.4',
+    python_requires='>=3.10',
 )

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,18 @@ setuptools.setup(
     description="Python mouse and keyboard input automation for Windows using Direct Input.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/reggx/pydirectinput",
-    packages=setuptools.find_packages(),
+    url="https://github.com/reggx/pydirectinput_rgx",
+    packages=['pydirectinput'],
     classifiers=[
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: Microsoft :: Windows",
+        "Environment :: Win32 (MS Windows)",
+        "Topic :: Software Development :: Libraries",
+        "Typing :: Typed",
     ],
     python_requires='>=3.10',
+    license='MIT',
+    keywords='python directinput wrapper abstraction input gui automation'
 )

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="PyDirectInput",
-    version="1.0.4",
-    # author="Ben Johnson",
-    # author_email="ben@learncodebygaming.com",
+    name="pydirectinput_rgx",
+    version="2.0.0",
+    author="ReggX",
+    author_email="dev@reggx.eu",
     description="Python mouse and keyboard input automation for Windows using Direct Input.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    # url="https://github.com/learncodebygaming/pydirectinput",
+    url="https://github.com/reggx/pydirectinput",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -22,12 +22,12 @@ def mouse_return_accuracy():
     # when the mouse is moved relative, and then reversed relative again, confirm
     # that the cursor returns to the same position
     pydirectinput.moveTo(300, 300)
-    pos_start = pydirectinput._position()  # pyright: ignore[reportPrivateUsage]
+    pos_start = pydirectinput.position()  # pyright: ignore[reportPrivateUsage]
     time.sleep(1)
     pydirectinput.move(100, 0)
     time.sleep(1)
     pydirectinput.move(-100, 0)
-    pos_end = pydirectinput._position()  # pyright: ignore[reportPrivateUsage]
+    pos_end = pydirectinput.position()  # pyright: ignore[reportPrivateUsage]
     print(f"{pos_start} == {pos_end}? {pos_start == pos_end}")
 
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,5 +1,7 @@
+# native imports
 import time
 
+# local imports
 import pydirectinput
 
 
@@ -20,10 +22,13 @@ def mouse_return_accuracy():
     # when the mouse is moved relative, and then reversed relative again, confirm
     # that the cursor returns to the same position
     pydirectinput.moveTo(300, 300)
+    pos_start = pydirectinput.position()
     time.sleep(1)
     pydirectinput.move(100, 0)
     time.sleep(1)
     pydirectinput.move(-100, 0)
+    pos_end = pydirectinput.position()
+    print(f"{pos_start} == {pos_end}? {pos_start == pos_end}")
 
 
 def clicks_and_typing():
@@ -87,16 +92,24 @@ def relative_mouse():
 if __name__ == '__main__':
 
     time.sleep(4)
-    # trace_square()
-    # time.sleep(1)
-    # mouse_return_accuracy()
-    # time.sleep(1)
-    # clicks_and_typing()
-    # time.sleep(6)
-    # wasd_movement()
-    # time.sleep(1)
-    # basic_click()
-    # time.sleep(6)
-    # arrow_keys()
+    print("trace_square")
+    trace_square()
     time.sleep(1)
+    print("mouse_return_accuracy")
+    mouse_return_accuracy()
+    time.sleep(1)
+    print("clicks_and_typing")
+    clicks_and_typing()
+    time.sleep(1)
+    print("wasd_movement")
+    wasd_movement()
+    time.sleep(1)
+    print("basic_click")
+    basic_click()
+    time.sleep(1)
+    print("arrow_keys")
+    arrow_keys()
+    time.sleep(1)
+    print("relative_mouse")
     relative_mouse()
+    print("done")

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -17,7 +17,7 @@ def trace_square():
 
 
 def mouse_return_accuracy():
-    # when the mouse is moved relative, and then reversed relative again, confirm 
+    # when the mouse is moved relative, and then reversed relative again, confirm
     # that the cursor returns to the same position
     pydirectinput.moveTo(300, 300)
     time.sleep(1)
@@ -34,7 +34,7 @@ def clicks_and_typing():
     time.sleep(0.05)
     pydirectinput.keyUp('g')
     time.sleep(0.05)
-    pydirectinput.press(['c','v','t'])
+    pydirectinput.press(['c', 'v', 't'])
     time.sleep(0.05)
     pydirectinput.typewrite('myword')
 
@@ -85,22 +85,18 @@ def relative_mouse():
 
 
 if __name__ == '__main__':
-    
+
     time.sleep(4)
-    #trace_square()
-    #time.sleep(1)
-    #mouse_return_accuracy()
-    #time.sleep(1)
-    #clicks_and_typing()
-    #time.sleep(6)
-    #wasd_movement()
-    #time.sleep(1)
-    #basic_click()
-    #time.sleep(6)
-    #arrow_keys()
+    # trace_square()
+    # time.sleep(1)
+    # mouse_return_accuracy()
+    # time.sleep(1)
+    # clicks_and_typing()
+    # time.sleep(6)
+    # wasd_movement()
+    # time.sleep(1)
+    # basic_click()
+    # time.sleep(6)
+    # arrow_keys()
     time.sleep(1)
     relative_mouse()
-
-    
-    
-

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -22,12 +22,12 @@ def mouse_return_accuracy():
     # when the mouse is moved relative, and then reversed relative again, confirm
     # that the cursor returns to the same position
     pydirectinput.moveTo(300, 300)
-    pos_start = pydirectinput.position()
+    pos_start = pydirectinput._position()  # pyright: ignore[reportPrivateUsage]
     time.sleep(1)
     pydirectinput.move(100, 0)
     time.sleep(1)
     pydirectinput.move(-100, 0)
-    pos_end = pydirectinput.position()
+    pos_end = pydirectinput._position()  # pyright: ignore[reportPrivateUsage]
     print(f"{pos_start} == {pos_end}? {pos_start == pos_end}")
 
 

--- a/tests/coordinate_test.py
+++ b/tests/coordinate_test.py
@@ -1,0 +1,41 @@
+'''
+Test how well Windows normalized coordinates map to your real screen pixels.
+'''
+# pyright: reportPrivateUsage=false
+
+import pydirectinput
+
+
+# ------------------------------------------------------------------------------
+def coordinate_conversion_test(  # pyright: ignore[reportUnusedFunction]
+    virtual: bool = False,
+    dump: bool = False
+) -> None:
+    ''''''
+    def _raw_moveTo(x: int, y: int, virtual: bool = False) -> None:
+        dwFlags: int = (
+          pydirectinput._MOUSEEVENTF_MOVE | pydirectinput._MOUSEEVENTF_ABSOLUTE
+        )
+        if virtual:
+            dwFlags |= pydirectinput._MOUSEEVENTF_VIRTUALDESK
+        pydirectinput._send_input(pydirectinput._create_mouse_input(
+            dx=x, dy=y,
+            dwFlags=dwFlags
+        ))
+
+    results: list[tuple[int, int]] = []
+    _raw_moveTo(0, 32000, virtual=virtual)
+    pydirectinput._sleep(1)
+    for i in range(65536):
+        _raw_moveTo(i, 32000, virtual=virtual)
+        x, _ = pydirectinput._position()
+        results.append((i, x))
+    if dump:
+        import json
+        with open('coordinates.json', 'w')as fp:
+            json.dump(results, fp)
+# ------------------------------------------------------------------------------
+
+
+if __name__ == '__main__':
+    coordinate_conversion_test(virtual=True, dump=True)

--- a/tests/coordinate_test.py
+++ b/tests/coordinate_test.py
@@ -14,7 +14,8 @@ def coordinate_conversion_test(  # pyright: ignore[reportUnusedFunction]
     ''''''
     def _raw_moveTo(x: int, y: int, virtual: bool = False) -> None:
         dwFlags: int = (
-          pydirectinput._MOUSEEVENTF_MOVE | pydirectinput._MOUSEEVENTF_ABSOLUTE
+            pydirectinput._MOUSEEVENTF_MOVE
+            | pydirectinput._MOUSEEVENTF_ABSOLUTE
         )
         if virtual:
             dwFlags |= pydirectinput._MOUSEEVENTF_VIRTUALDESK
@@ -28,7 +29,7 @@ def coordinate_conversion_test(  # pyright: ignore[reportUnusedFunction]
     pydirectinput._sleep(1)
     for i in range(65536):
         _raw_moveTo(i, 32000, virtual=virtual)
-        x, _ = pydirectinput._position()
+        x, _ = pydirectinput.position()
         results.append((i, x))
     if dump:
         import json


### PR DESCRIPTION
Hey there,

I needed to make some changes for a private project of mine.

What began as a small set of changes to conform to mypy --strict ended up in a complete overhaul of the project, implementing more of PyAutoGUI's functions directly into pydirectinput and extending function signatures with optional keyword-only arguments.

Your welcome to take the changes and integrate them upstream, there are some pitfalls though:

The whole package is in-line typed, which means it will need at least Python 3.7 to run.
It's also modifying the README to match my forked pypi package that I use for other stuff, so it can't be merged as is. It is on a seperate branch, so you're free to modify it before merging.

Please let me know if you're interested in merging this.

(Had to redo #36 because I accidentally removed the branch)