### PR TITLE
Added keyboard layout adjustment

### DIFF
--- a/pydirectinput/__init__.py
+++ b/pydirectinput/__init__.py
@@ -168,8 +168,10 @@ KEYBOARD_MAPPING = {
     'right': MapVirtualKey(0x27, MAPVK_VK_TO_VSC),
 }
 
-# C struct redefinitions
+for c in range(32, 92):
+    KEYBOARD_MAPPING[chr(c).lower()] = MapVirtualKey(c, MAPVK_VK_TO_VSC)
 
+# C struct redefinitions
 PUL = ctypes.POINTER(ctypes.c_ulong)
 
 


### PR DESCRIPTION
Hey Ben!

I recently had to switch from using pyautogui to pydirectinput for one of my projects.

When trying to press `Z`, I realized the actual outcome was `Y`, because your scancodes are QWERTY based, which means on a QWERTZ based keyboard, Y comes out as Z and vice versa, even worse for AZERTY layouts!

So, as a quick fix for this (rather pesky) issue, we can simply use the `MapVirtualKey` as you already have been for the arrow keys, to make this slightly less code, we can simply iterate over all the keycodes and map them to their character.

```py
for c in range(32, 92):
    KEYBOARD_MAPPING[chr(c).lower()] = MapVirtualKey(c, MAPVK_VK_TO_VSC)
```

Since the function comes from ctypes too, theres no need for further imports and changes.

Hope this helps and is lightweight enough for you to simply accept it.

Thanks for your great work and videos!
